### PR TITLE
Add default timeout to requests

### DIFF
--- a/pennylane_ionq/api_client.py
+++ b/pennylane_ionq/api_client.py
@@ -129,7 +129,7 @@ class APIClient:
 
         self.HEADERS = {"User-Agent": self.USER_AGENT}
 
-        # Ten minute timout on requests.
+        # Ten minute timeout on requests.
         self.TIMEOUT_SECONDS = 60 * 10
 
         if self.AUTHENTICATION_TOKEN:

--- a/pennylane_ionq/api_client.py
+++ b/pennylane_ionq/api_client.py
@@ -129,6 +129,9 @@ class APIClient:
 
         self.HEADERS = {"User-Agent": self.USER_AGENT}
 
+        # Ten minute timout on requests.
+        self.TIMEOUT_SECONDS = 60 * 10
+
         if self.AUTHENTICATION_TOKEN:
             self.set_authorization_header(self.AUTHENTICATION_TOKEN)
         else:
@@ -178,6 +181,8 @@ class APIClient:
             raise TypeError("Unexpected or unsupported method provided")
 
         params["headers"] = self.HEADERS
+
+        params["timeout"] = self.TIMEOUT_SECONDS
 
         try:
             response = method(**params)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -113,6 +113,7 @@ class TestAPIClient:
         client = api_client.APIClient(authentication_token="")
         assert client.BASE_URL.startswith("https://")
         assert client.HEADERS["User-Agent"] == client.USER_AGENT
+        assert client.TIMEOUT_SECONDS == 600
 
     def test_set_authorization_header(self):
         """


### PR DESCRIPTION
Adds a default timeout to requests of ten minutes.  This is a timeout both on connect and request.  

Without this, it is possible for the polling for complete jobs to hang indefinitely (we observed what we think was this while running against the QPU).

Ten minutes is a rather large timeout and was pulled out of a bag.