### PR TITLE
Pass shots to IonQ API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,7 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
+    if: github.repository == 'PennyLaneAI/pennylane-ionq'
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
-    if: github.repository == 'PennyLaneAI/pennylane-ionq'
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Cancel Previous Runs

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -94,7 +94,12 @@ class IonQDevice(QubitDevice):
         self._prob_array = None
         self.histogram = None
         self.circuit = {"qubits": self.num_wires, "circuit": []}
-        self.job = {"lang": "json", "body": self.circuit, "target": self.target}
+        self.job = {
+            "lang": "json",
+            "body": self.circuit,
+            "target": self.target,
+            "shots": self.shots
+        }
 
     @property
     def operations(self):

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -98,7 +98,7 @@ class IonQDevice(QubitDevice):
             "lang": "json",
             "body": self.circuit,
             "target": self.target,
-            "shots": self.shots
+            "shots": self.shots,
         }
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,5 +101,6 @@ def device(request, shots):
 @pytest.fixture
 def requires_api():
     """Skips a test if the API key is not available"""
-    if os.environ.get("IONQ_API_KEY", None) is None:
+    key = os.environ.get("IONQ_API_KEY", None)
+    if key is None or not key:
         pytest.skip("Skipping test as API key is not available")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import numpy as np
 import pytest
 
@@ -95,3 +96,10 @@ def device(request, shots):
         return device(wires=n, shots=shots)
 
     return _device
+
+
+@pytest.fixture
+def requires_api():
+    """Skips a test if the API key is not available"""
+    if os.environ.get("IONQ_API_KEY", None) is None:
+        pytest.skip("Skipping test as API key is not available")

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -36,7 +36,7 @@ status_codes = requests.status_codes.codes
 
 @pytest.fixture
 def client():
-    return api_client.APIClient()
+    return api_client.APIClient(api_key="test")
 
 
 SAMPLE_JOB_CREATE_RESPONSE = {
@@ -110,7 +110,7 @@ class TestAPIClient:
         """
         Test that initializing a default client generates an APIClient with the expected params.
         """
-        client = api_client.APIClient(authentication_token="")
+        client = api_client.APIClient(api_key="test")
         assert client.BASE_URL.startswith("https://")
         assert client.HEADERS["User-Agent"] == client.USER_AGENT
 
@@ -118,7 +118,7 @@ class TestAPIClient:
         """
         Test that the authentication token is added to the header correctly.
         """
-        client = api_client.APIClient()
+        client = api_client.APIClient(api_key="test")
 
         authentication_token = MagicMock()
         client.set_authorization_header(authentication_token)
@@ -295,7 +295,7 @@ class TestResourceManager:
         monkeypatch.setattr(requests, "get", lambda url, headers: mock_get_response)
         monkeypatch.setattr(requests, "post", lambda url, headers, data: mock_raise(MockException))
 
-        client = api_client.APIClient(debug=True)
+        client = api_client.APIClient(debug=True, api_key="test")
 
         assert client.DEBUG is True
         assert client.errors == []
@@ -318,7 +318,7 @@ class TestJob:
         the Job instance have been set correctly and match the mock data.
         """
         monkeypatch.setattr(requests, "post", lambda url, headers, data: MockPOSTResponse(201))
-        job = Job()
+        job = Job(api_key="test")
         job.manager.create(params={})
 
         keys_to_check = SAMPLE_JOB_CREATE_RESPONSE.keys()
@@ -330,7 +330,7 @@ class TestJob:
         Tests that the correct error code is returned when a bad request is sent to the server.
         """
         monkeypatch.setattr(requests, "post", lambda url, headers, data: MockPOSTResponse(400))
-        job = Job()
+        job = Job(api_key="test")
 
         with pytest.raises(Exception):
             job.manager.create(params={})

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -47,7 +47,7 @@ class TestDeviceIntegration:
     def test_shots(self, shots, monkeypatch, mocker, tol):
         """Test that shots are correctly specified when submitting a job to the API."""
 
-        monkeypatch.setattr(requests, "post", lambda url, data, headers: (url, data, headers))
+        monkeypatch.setattr(requests, "post", lambda url, timeout, data, headers: (url, data, headers))
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 


### PR DESCRIPTION
Shots were not being passed to the API, causing all jobs to run 100 shots, the IonQ Default.

I did not see a test of the request structure, let me know if you'd like me to try to add one.

Also not sure on your style for wrapping, so feel free to nit :) 