### PR TITLE
Use real samples on QPU device

### DIFF
--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -200,11 +200,6 @@ class IonQDevice(QubitDevice):
 
         return self.estimate_probability(wires=wires, shot_range=shot_range, bin_size=bin_size)
 
-    def generate_samples(self):
-        number_of_states = 2 ** self.num_wires
-        samples = self.sample_basis_states(number_of_states, self.prob)
-        return QubitDevice.states_to_binary(samples, self.num_wires)
-
 
 class SimulatorDevice(IonQDevice):
     r"""Simulator device for IonQ.
@@ -226,6 +221,11 @@ class SimulatorDevice(IonQDevice):
     def __init__(self, wires, *, shots=1024, api_key=None):
         super().__init__(wires=wires, target="simulator", shots=shots, api_key=api_key)
 
+    def generate_samples(self):
+        number_of_states = 2 ** self.num_wires
+        samples = self.sample_basis_states(number_of_states, self.prob)
+        return QubitDevice.states_to_binary(samples, self.num_wires)
+
 
 class QPUDevice(IonQDevice):
     r"""QPU device for IonQ.
@@ -246,3 +246,11 @@ class QPUDevice(IonQDevice):
 
     def __init__(self, wires, *, shots=1024, api_key=None):
         super().__init__(wires=wires, target="qpu", shots=shots, api_key=api_key)
+
+    def generate_samples(self):
+        number_of_states = 2 ** self.num_wires
+        counts = np.rint(
+            self.prob * self.shots, out=np.zeros(number_of_states, dtype=int), casting="unsafe"
+        )
+        samples = np.repeat(np.arange(number_of_states), counts)
+        return QubitDevice.states_to_binary(samples, self.num_wires)

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -222,6 +222,7 @@ class SimulatorDevice(IonQDevice):
         super().__init__(wires=wires, target="simulator", shots=shots, api_key=api_key)
 
     def generate_samples(self):
+        """Generates samples by random sampling with the probabilities returned by the simulator."""
         number_of_states = 2 ** self.num_wires
         samples = self.sample_basis_states(number_of_states, self.prob)
         return QubitDevice.states_to_binary(samples, self.num_wires)
@@ -248,9 +249,16 @@ class QPUDevice(IonQDevice):
         super().__init__(wires=wires, target="qpu", shots=shots, api_key=api_key)
 
     def generate_samples(self):
+        """Generates samples from the qpu.
+
+        Note that the order of the samples returned here is not indicative of the order in which
+        the experiments were done, but is instead controlled by a random shuffle (and hence
+        set by numpy random seed.)
+        """
         number_of_states = 2 ** self.num_wires
         counts = np.rint(
             self.prob * self.shots, out=np.zeros(number_of_states, dtype=int), casting="unsafe"
         )
         samples = np.repeat(np.arange(number_of_states), counts)
-        return QubitDevice.states_to_binary(samples, self.num_wires)
+        random_samples = np.random.shuffle(samples)
+        return QubitDevice.states_to_binary(random_samples, self.num_wires)

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -253,7 +253,7 @@ class QPUDevice(IonQDevice):
 
         Note that the order of the samples returned here is not indicative of the order in which
         the experiments were done, but is instead controlled by a random shuffle (and hence
-        set by numpy random seed.)
+        set by numpy random seed).
         """
         number_of_states = 2 ** self.num_wires
         counts = np.rint(

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -260,5 +260,5 @@ class QPUDevice(IonQDevice):
             self.prob * self.shots, out=np.zeros(number_of_states, dtype=int), casting="unsafe"
         )
         samples = np.repeat(np.arange(number_of_states), counts)
-        random_samples = np.random.shuffle(samples)
-        return QubitDevice.states_to_binary(random_samples, self.num_wires)
+        np.random.shuffle(samples)
+        return QubitDevice.states_to_binary(samples, self.num_wires)


### PR DESCRIPTION
In the case of the actual QPU, instead of resample from the returned results, one should just use the actual samples.  

This is a bit convoluted because the api currently returns probabilities instead of counts, so should be upgraded if/when counts are exposed.  