### PR TITLE
convert parameters to float for serialization

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,11 @@
+requirements_file: doc/requirements.txt
+
+build:
+    image: latest
+
+python:
+    version: 3.8
+
+# Don't build any extra formats
+formats:
+    - none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.17.0-dev
+# Release 0.20.0-dev
 
 ### New features since last release
 
@@ -10,9 +10,14 @@
 
 ### Bug fixes
 
+* Parameters are converted to floats, unwrapping interface data types.
+  [(#41)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/41)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Christina Lee
 
 ---
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,2 @@
+docutils==0.16
 sphinx-automodapi

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
+numpy==1.21.4
 docutils==0.16
 sphinx-automodapi

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -111,14 +111,13 @@ class IonQDevice(QubitDevice):
         return set(self._operation_map.keys())
 
     def apply(self, operations, **kwargs):
+        self.reset()
         rotations = kwargs.pop("rotations", [])
 
         for i, operation in enumerate(operations):
             if i > 0 and operation.name in {"BasisState", "QubitStateVector"}:
                 raise DeviceError(
-                    "The operation {} is only supported at the beginning of a circuit.".format(
-                        operation.name
-                    )
+                    f"The operation {operation.name} is only supported at the beginning of a circuit."
                 )
             self._apply_operation(operation)
 
@@ -126,6 +125,7 @@ class IonQDevice(QubitDevice):
         for operation in rotations:
             self._apply_operation(operation)
 
+        # print(self.job)
         self._submit_job()
 
     def _apply_operation(self, operation):
@@ -145,7 +145,7 @@ class IonQDevice(QubitDevice):
             gate["target"] = wires[0]
 
         if par:
-            gate["rotation"] = par[0]
+            gate["rotation"] = float(par[0])
 
         self.circuit["circuit"].append(gate)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,18 +25,18 @@ np.random.seed(42)
 # Some useful global variables
 
 # single qubit unitary matrix
-U = np.array([[0.83645892 - 0.40533293j, -0.20215326 + 0.30850569j],
-              [-0.23889780 - 0.28101519j, -0.88031770 - 0.29832709j]])
+U = np.array(
+    [
+        [0.83645892 - 0.40533293j, -0.20215326 + 0.30850569j],
+        [-0.23889780 - 0.28101519j, -0.88031770 - 0.29832709j],
+    ]
+)
 
 # two qubit unitary matrix
-U2 = np.array([[0, 1, 1, 1],
-               [1, 0, 1, -1],
-               [1, -1, 0, 1],
-               [1, 1, -1, 0]]) / np.sqrt(3)
+U2 = np.array([[0, 1, 1, 1], [1, 0, 1, -1], [1, -1, 0, 1], [1, 1, -1, 0]]) / np.sqrt(3)
 
 # single qubit Hermitian observable
-A = np.array([[1.02789352, 1.61296440 - 0.3498192j],
-              [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
+A = np.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
 
 
 # ==========================================================
@@ -58,6 +58,7 @@ shortnames = [d.short_name for d in analytic_devices + hw_devices]
 # ==========================================================
 # pytest fixtures
 
+
 @pytest.fixture
 def tol(shots):
     """Numerical tolerance to be used in tests."""
@@ -75,16 +76,17 @@ def tol(shots):
 @pytest.fixture
 def init_state(scope="session"):
     """Fixture to create an n-qubit initial basis state"""
+
     def _init_state(n):
         state = np.random.randint(0, 2, [n])
-        ket = np.zeros([2**n])
+        ket = np.zeros([2 ** n])
         ket[np.ravel_multi_index(state, [2] * n)] = 1
         return state, ket
 
     return _init_state
 
 
-@pytest.fixture(params=analytic_devices+hw_devices)
+@pytest.fixture(params=analytic_devices + hw_devices)
 def device(request, shots):
     """Fixture to initialize and return a PennyLane device"""
     device = request.param

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -38,17 +38,14 @@ def client():
     return api_client.APIClient(api_key="test")
 
 
-SAMPLE_JOB_CREATE_RESPONSE = {
-    "id": "a6a146d0-d64f-42f4-8b17-ec761fbab7fd",
-    "status": "ready"
-}
+SAMPLE_JOB_CREATE_RESPONSE = {"id": "a6a146d0-d64f-42f4-8b17-ec761fbab7fd", "status": "ready"}
 
 SAMPLE_JOB_RESPONSE = {
-  "id": "617a1f8b-59d4-435d-aa33-695433d7155e",
-  "type": "simulation",
-  "status": "running",
-  "request": "1490932820",
-  "response": "1490932834",
+    "id": "617a1f8b-59d4-435d-aa33-695433d7155e",
+    "type": "simulation",
+    "status": "running",
+    "request": "1490932820",
+    "response": "1490932834",
 }
 
 
@@ -281,10 +278,12 @@ class TestResourceManager:
         """
         Tests that the client object keeps track of responses and errors when debug mode is enabled.
         """
+
         class MockException(Exception):
             """
             A mock exception to ensure that the exception raised is the expected one.
             """
+
             pass
 
         def mock_raise(exception):
@@ -293,7 +292,9 @@ class TestResourceManager:
         mock_get_response = MockGETResponse(200)
 
         monkeypatch.setattr(requests, "get", lambda url, timeout, headers: mock_get_response)
-        monkeypatch.setattr(requests, "post", lambda url, timeout, headers, data: mock_raise(MockException))
+        monkeypatch.setattr(
+            requests, "post", lambda url, timeout, headers, data: mock_raise(MockException)
+        )
 
         client = api_client.APIClient(debug=True, api_key="test")
 
@@ -317,7 +318,9 @@ class TestJob:
         Tests a successful Job creatioin with a mock POST response. Asserts that all fields on
         the Job instance have been set correctly and match the mock data.
         """
-        monkeypatch.setattr(requests, "post", lambda url, timeout, headers, data: MockPOSTResponse(201))
+        monkeypatch.setattr(
+            requests, "post", lambda url, timeout, headers, data: MockPOSTResponse(201)
+        )
         job = Job(api_key="test")
         job.manager.create(params={})
 
@@ -329,7 +332,9 @@ class TestJob:
         """
         Tests that the correct error code is returned when a bad request is sent to the server.
         """
-        monkeypatch.setattr(requests, "post", lambda url, timeout, headers, data: MockPOSTResponse(400))
+        monkeypatch.setattr(
+            requests, "post", lambda url, timeout, headers, data: MockPOSTResponse(400)
+        )
         job = Job(api_key="test")
 
         with pytest.raises(Exception):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -20,7 +20,7 @@ import requests
 
 from conftest import shortnames
 from pennylane_ionq.api_client import ResourceManager, Job, Field
-from pennylane_ionq.device import QPUDevice
+from pennylane_ionq.device import QPUDevice, IonQDevice
 
 FAKE_API_KEY = "ABC123"
 
@@ -44,7 +44,7 @@ class TestDevice:
         dev.histogram = histogram
 
         sample1 = dev.generate_samples()
-        assert dev.histogram == histogram # make sure histogram is still the same
+        assert dev.histogram == histogram  # make sure histogram is still the same
         sample2 = dev.generate_samples()
         assert not np.all(sample1 == sample2)  # some rows are different
 
@@ -113,7 +113,7 @@ class TestDeviceIntegration:
 
         a = 0.543
         b = 0.123
-        c = 0.987
+        c = qml.numpy.array(0.987, requires_grad=False)
 
         @qml.qnode(dev)
         def circuit(x, y, z):
@@ -144,3 +144,49 @@ class TestDeviceIntegration:
         None if no job has yet been run."""
         dev = qml.device(d, wires=1, shots=1)
         assert dev.prob is None
+
+
+class TestJobAttribute:
+    """Tests job creation with mocked submission."""
+
+    def test_nonparametrized_tape(self, mocker):
+        """Tests job attribute after single paulix tape."""
+
+        def mock_submit_job(*args):
+            pass
+
+        mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
+        dev = IonQDevice(wires=(0,))
+
+        with qml.tape.QuantumTape() as tape:
+            qml.PauliX(0)
+
+        dev.apply(tape.operations)
+
+        assert dev.job["lang"] == "json"
+        assert dev.job["body"]["qubits"] == 1
+
+        assert len(dev.job["body"]["circuit"]) == 1
+        assert dev.job["body"]["circuit"][0] == {"gate": "x", "target": 0}
+
+    def test_parameterized_op(self, mocker):
+        """Tests job attribute several parameterized operations."""
+
+        def mock_submit_job(*args):
+            pass
+
+        mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
+        dev = IonQDevice(wires=(0,))
+
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(1.2345, wires=0)
+            qml.RY(qml.numpy.array(2.3456), wires=0)
+
+        dev.apply(tape.operations)
+
+        assert dev.job["lang"] == "json"
+        assert dev.job["body"]["qubits"] == 1
+
+        assert len(dev.job["body"]["circuit"]) == 2
+        assert dev.job["body"]["circuit"][0] == {"gate": "rx", "target": 0, "rotation": 1.2345}
+        assert dev.job["body"]["circuit"][1] == {"gate": "ry", "target": 0, "rotation": 2.3456}


### PR DESCRIPTION
This PR converts parameters to float, as neither JSON nor IONQ can handle numpy `ndarray` objects.

Note: NumPy was pinned as `numpy==1.21.4` in the docs `requirements.txt` because ReadTheDocs was pulling in a release candidate version of NumPy and this resulted in issues with the string format of the version number. This pinning may be changed at a later point, if required.