### PR TITLE
Allow overriding target on device

### DIFF
--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -224,8 +224,8 @@ class SimulatorDevice(IonQDevice):
     name = "IonQ Simulator PennyLane plugin"
     short_name = "ionq.simulator"
 
-    def __init__(self, wires, *, shots=1024, api_key=None):
-        super().__init__(wires=wires, target="simulator", shots=shots, api_key=api_key)
+    def __init__(self, wires, *, target="simulator", shots=1024, api_key=None):
+        super().__init__(wires=wires, target=target, shots=shots, api_key=api_key)
 
     def generate_samples(self):
         """Generates samples by random sampling with the probabilities returned by the simulator."""
@@ -251,8 +251,8 @@ class QPUDevice(IonQDevice):
     name = "IonQ QPU PennyLane plugin"
     short_name = "ionq.qpu"
 
-    def __init__(self, wires, *, shots=1024, api_key=None):
-        super().__init__(wires=wires, target="qpu", shots=shots, api_key=api_key)
+    def __init__(self, wires, *, target="qpu", shots=1024, api_key=None):
+        super().__init__(wires=wires, target=target, shots=shots, api_key=api_key)
 
     def generate_samples(self):
         """Generates samples from the qpu.

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -99,7 +99,7 @@ class TestDeviceIntegration:
         monkeypatch.setattr(Job, "is_complete", False)
         monkeypatch.setattr(Job, "is_failed", True)
 
-        dev = IonQDevice(wires=(0,))
+        dev = IonQDevice(wires=(0,), api_key="test")
         with pytest.raises(JobExecutionError):
             dev._submit_job()
 
@@ -182,7 +182,7 @@ class TestJobAttribute:
             pass
 
         mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
-        dev = IonQDevice(wires=(0,))
+        dev = IonQDevice(wires=(0,), target="foo")
 
         with qml.tape.QuantumTape() as tape:
             qml.PauliX(0)
@@ -190,6 +190,7 @@ class TestJobAttribute:
         dev.apply(tape.operations)
 
         assert dev.job["lang"] == "json"
+        assert dev.job["target"] == "foo"
         assert dev.job["body"]["qubits"] == 1
 
         assert len(dev.job["body"]["circuit"]) == 1


### PR DESCRIPTION
Alternative to https://github.com/PennyLaneAI/PennyLane-IonQ/pull/49 for supporting more targets.