### PR TITLE
[Bug] Normalize probabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Jon Donovan, Antal Száva
+Jon Donovan, Christina Lee, Antal Száva
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Bug Fixes
 
-* Since the probabilities returned don't always perfectly sum to one, they are now normalized.
+* Since the histogram of probabilities returned from the remote simulator does not always sum exactly to one,
+  the PennyLane device normalizes them to higher precision.
   [(#53)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/53)
 
 ### Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   `SimulatorDevice` class for general IonQ devices.
   [(#50)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/50)
 
+### Bug Fixes
+
+* Since the probabilities returned don't always perfectly sum to one, they are now normalized.
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 * Since the probabilities returned don't always perfectly sum to one, they are now normalized.
+  [(#53)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/53)
 
 ### Contributors
 

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -129,7 +129,6 @@ class IonQDevice(QubitDevice):
         for operation in rotations:
             self._apply_operation(operation)
 
-        # print(self.job)
         self._submit_job()
 
     def _apply_operation(self, operation):
@@ -194,7 +193,11 @@ class IonQDevice(QubitDevice):
 
             # convert the sparse probs into a probability array
             self._prob_array = np.zeros([2**self.num_wires])
-            self._prob_array[idx] = np.fromiter(self.histogram.values(), float)
+
+            # histogram values don't always perfectly sum to exactly one
+            histogram_values = self.histogram.values()
+            norm = sum(histogram_values)
+            self._prob_array[idx] = np.fromiter(histogram_values, float)/norm
 
         return self._prob_array
 

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -197,7 +197,7 @@ class IonQDevice(QubitDevice):
             # histogram values don't always perfectly sum to exactly one
             histogram_values = self.histogram.values()
             norm = sum(histogram_values)
-            self._prob_array[idx] = np.fromiter(histogram_values, float)/norm
+            self._prob_array[idx] = np.fromiter(histogram_values, float) / norm
 
         return self._prob_array
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def init_state(scope="session"):
 
     def _init_state(n):
         state = np.random.randint(0, 2, [n])
-        ket = np.zeros([2 ** n])
+        ket = np.zeros([2**n])
         ket[np.ravel_multi_index(state, [2] * n)] = 1
         return state, ket
 


### PR DESCRIPTION
The returned probabilities do not always perfectly sum to one.  This difference seems to be slight, about 1e-5, but it is enough to cause `np.random.choice` to complain.  Therefore we now normalize the probabilities.