### PR TITLE
Revert "Version Bump (#64)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
-# Release 0.27.0
+# Release 0.24.0-dev
 
 ### New features since last release
 
 * Add support for various IonQ native gates.
   [(#55)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/55)
+
+### Breaking changes
+
+### Improvements
+
+### Documentation
+
+### Bug fixes
 
 ### Contributors
 

--- a/pennylane_ionq/_version.py
+++ b/pennylane_ionq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.27.0"
+__version__ = "0.24.0-dev"


### PR DESCRIPTION
This plugin wasn't released with PennyLane v0.27.0. This reverts the docs updates, and we'll be sure to release it with PennyLane 0.28 instead.