### PR TITLE
use correct pypi upload action version

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -32,7 +32,7 @@ jobs:
           pl-device-test --device=ionq.simulator --tb=short --skip-ops --shots=10000
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI }}


### PR DESCRIPTION
As instructions say [here](https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-) (a warning came up when uploading various things for 0.31)