### PR TITLE
Add support for `StatePrep`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ### New features since last release
 
-### Breaking changes
+### Breaking changes 💔
 
-### Improvements
+### Improvements 🛠
 
 * Added support for `qml.StatePrep` as a state preparation operation.
   [(#77)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/77)
 
-### Documentation
+### Documentation 📝
 
-### Bug fixes
+### Bug fixes 🐛
 
-### Contributors
+### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-# Release 0.29.0-dev
+# Release 0.32.0-dev
 
 ### New features since last release
 
 ### Breaking changes
 
 ### Improvements
+
+* Added support for `qml.StatePrep` as a state preparation operation.
+  [(#77)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/77)
 
 ### Documentation
 
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+ Jay Soni
 
 ---
 # Release 0.28.0

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -137,7 +137,7 @@ class IonQDevice(QubitDevice):
             warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
 
         for i, operation in enumerate(operations):
-            if i > 0 and operation.name in {"BasisState", "QubitStateVector"}:
+            if i > 0 and operation.name in {"BasisState", "QubitStateVector", "StatePrep"}:
                 raise DeviceError(
                     f"The operation {operation.name} is only supported at the beginning of a circuit."
                 )

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 numpy
-git+https://github.com/PennyLaneAI/pennylane.git
+pennylane
 python-dateutil
 requests

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
 numpy
-pennylane
+git+https://github.com/PennyLaneAI/pennylane.git
 python-dateutil
 requests


### PR DESCRIPTION
Following the work [here](https://github.com/PennyLaneAI/pennylane/pull/4450/), we make sure that the PennyLane-IonQ plugin supports both operators and defaults to using `StatePrep` where appropriate until it is deprecated.