### PR TITLE
Enable qpu.backend for IonQ backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 This release contains contributions from (in alphabetical order):
 
+Spencer Churchill
+
 ---
 # Release 0.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Improvements
 
+* Use new `backend` field to specify `qpu`.
+  [(#81)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/81)
+
 ### Documentation
 
 ### Bug fixes

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,8 @@ You can instantiate the IonQ devices for PennyLane as follows:
 
     import pennylane as qml
     dev1 = qml.device('ionq.simulator', wires=2, shots=1000)
-    dev2 = qml.device('ionq.qpu', backend='harmony', wires=2, shots=1000)
+    dev2 = qml.device('ionq.qpu.harmony', wires=2, shots=1000)
+    dev3 = qml.device('ionq.qpu', backend='aria-1', wires=2, shots=1000)
 
 These devices can then be used just like other devices for the definition and evaluation of
 quantum circuits within PennyLane. For more details and ideas, see the

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ You can instantiate the IonQ devices for PennyLane as follows:
 
     import pennylane as qml
     dev1 = qml.device('ionq.simulator', wires=2, shots=1000)
-    dev2 = qml.device('ionq.qpu', wires=2, shots=1000)
+    dev2 = qml.device('ionq.qpu', backend='harmony', wires=2, shots=1000)
 
 These devices can then be used just like other devices for the definition and evaluation of
 quantum circuits within PennyLane. For more details and ideas, see the

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ to the `PennyLane documentation <https://pennylane.readthedocs.io>`_.
 Contributing
 ============
 
-We welcome contributions—simply fork the PennyLane-IonQ repository, and then make a
+We welcome contributions-simply fork the PennyLane-IonQ repository, and then make a
 `pull request <https://help.github.com/articles/about-pull-requests/>`_ containing your contribution.
 All contributers to PennyLane-IonQ will be listed as contributors on the releases.
 

--- a/README.rst
+++ b/README.rst
@@ -108,8 +108,7 @@ You can instantiate the IonQ devices for PennyLane as follows:
 
     import pennylane as qml
     dev1 = qml.device('ionq.simulator', wires=2, shots=1000)
-    dev2 = qml.device('ionq.qpu.harmony', wires=2, shots=1000)
-    dev3 = qml.device('ionq.qpu', backend='aria-1', wires=2, shots=1000)
+    dev2 = qml.device('ionq.qpu', backend='aria-1', wires=2, shots=1000)
 
 These devices can then be used just like other devices for the definition and evaluation of
 quantum circuits within PennyLane. For more details and ideas, see the

--- a/doc/devices.rst
+++ b/doc/devices.rst
@@ -38,16 +38,17 @@ directly in PennyLane by specifying ``"ionq.simulator"``:
 Trapped-Ion QPU
 ---------------
 
-This device provides access to IonQ's trapped-ion QPU.
+This device provides access to IonQ's trapped-ion QPUs.
 Once the plugin has been installed, you can use this device
-directly in PennyLane by specifying ``"ionq.qpu"``:
+directly in PennyLane by specifying ``"ionq.qpu"`` with a
+``"backend"`` from `available backends <https://docs.ionq.com/#tag/jobs>`_:
 
 .. code-block:: python
 
     import pennylane as qml
     from pennylane_ionq import ops
 
-    dev = qml.device("ionq.qpu", wires=2)
+    dev = qml.device("ionq.qpu", backend="harmony", wires=2)
 
     @qml.qnode(dev)
     def circuit(x, y):

--- a/pennylane_ionq/__init__.py
+++ b/pennylane_ionq/__init__.py
@@ -16,5 +16,12 @@ PennyLane IonQ overview
 =======================
 """
 from .ops import GPI, GPI2, MS, XX, YY, ZZ
-from .device import SimulatorDevice, QPUDevice
+from .device import (
+    SimulatorDevice,
+    QPUDevice,
+    HarmonyQPUDevice,
+    Aria1QPUDevice,
+    Aria2QPUDevice,
+    Forte1QPUDevice,
+)
 from ._version import __version__

--- a/pennylane_ionq/__init__.py
+++ b/pennylane_ionq/__init__.py
@@ -16,12 +16,5 @@ PennyLane IonQ overview
 =======================
 """
 from .ops import GPI, GPI2, MS, XX, YY, ZZ
-from .device import (
-    SimulatorDevice,
-    QPUDevice,
-    HarmonyQPUDevice,
-    Aria1QPUDevice,
-    Aria2QPUDevice,
-    Forte1QPUDevice,
-)
+from .device import SimulatorDevice, QPUDevice
 from ._version import __version__

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -14,9 +14,7 @@
 """
 This module contains the device class for constructing IonQ devices for PennyLane.
 """
-import itertools
-import functools
-import warnings
+import os, warnings
 from time import sleep
 
 import numpy as np
@@ -143,7 +141,11 @@ class IonQDevice(QubitDevice):
             )
 
         for i, operation in enumerate(operations):
-            if i > 0 and operation.name in {"BasisState", "QubitStateVector", "StatePrep"}:
+            if i > 0 and operation.name in {
+                "BasisState",
+                "QubitStateVector",
+                "StatePrep",
+            }:
                 raise DeviceError(
                     f"The operation {operation.name} is only supported at the beginning of a circuit."
                 )
@@ -282,6 +284,7 @@ class QPUDevice(IonQDevice):
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['ancilla', 'q1', 'q2']``).
         gateset (str): the target gateset, either ``"qis"`` or ``"native"``.
+        backend (str): Optional specifier for an IonQ backend. Can be ``"harmony"``, ``"aria-1"``, etc.
         shots (int, list[int]): Number of circuit evaluations/random samples used to estimate
             expectation values of observables. If ``None``, the device calculates probability, expectation values,
             and variances analytically. If an integer, it specifies the number of samples to estimate these quantities.
@@ -297,12 +300,13 @@ class QPUDevice(IonQDevice):
         wires,
         *,
         target="qpu",
-        backend="",
+        backend=None,
         gateset="qis",
         shots=1024,
         api_key=None,
     ):
-        target += "." + backend
+        if backend is not None:
+            target += "." + backend
         super().__init__(
             wires=wires, target=target, gateset=gateset, shots=shots, api_key=api_key
         )
@@ -323,3 +327,54 @@ class QPUDevice(IonQDevice):
         samples = np.repeat(np.arange(number_of_states), counts)
         np.random.shuffle(samples)
         return QubitDevice.states_to_binary(samples, self.num_wires)
+
+
+# Specific Backends
+
+
+class HarmonyQPUDevice(QPUDevice):
+    def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
+        super().__init__(
+            wires,
+            target="qpu",
+            backend="harmony",
+            gateset=gateset,
+            shots=shots,
+            api_key=api_key,
+        )
+
+
+class Aria1QPUDevice(QPUDevice):
+    def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
+        super().__init__(
+            wires,
+            target="qpu",
+            backend="aria-1",
+            gateset=gateset,
+            shots=shots,
+            api_key=api_key,
+        )
+
+
+class Aria2QPUDevice(QPUDevice):
+    def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
+        super().__init__(
+            wires,
+            target="qpu",
+            backend="aria-2",
+            gateset=gateset,
+            shots=shots,
+            api_key=api_key,
+        )
+
+
+class Forte1QPUDevice(QPUDevice):
+    def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
+        super().__init__(
+            wires,
+            target="qpu",
+            backend="forte-1",
+            gateset=gateset,
+            shots=shots,
+            api_key=api_key,
+        )

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -305,8 +305,9 @@ class QPUDevice(IonQDevice):
         shots=1024,
         api_key=None,
     ):
-        if backend is not None:
-            target += "." + backend
+        self.backend = backend
+        if self.backend is not None:
+            target += "." + self.backend
         super().__init__(
             wires=wires, target=target, gateset=gateset, shots=shots, api_key=api_key
         )
@@ -327,98 +328,3 @@ class QPUDevice(IonQDevice):
         samples = np.repeat(np.arange(number_of_states), counts)
         np.random.shuffle(samples)
         return QubitDevice.states_to_binary(samples, self.num_wires)
-
-
-# Specific Backends
-
-
-class HarmonyQPUDevice(QPUDevice):
-    """
-    PennyLane device for the IonQ Harmony QPU backend.
-
-    Args:
-        wires (int or Iterable[Number, str]): Number of subsystems represented by the device, or iterable of unique labels for the subsystems.
-        gateset (str): Target gateset, either "qis" or "native".
-        shots (int): Number of circuit evaluations/random samples used to estimate expectation values and variances of observables.
-        api_key (str): The IonQ API key. If not provided, the environment
-            variable ``IONQ_API_KEY`` is used.
-    """
-
-    def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
-        super().__init__(
-            wires,
-            target="qpu",
-            backend="harmony",
-            gateset=gateset,
-            shots=shots,
-            api_key=api_key,
-        )
-
-
-class Aria1QPUDevice(QPUDevice):
-    """
-    PennyLane device for the IonQ Aria-1 QPU backend.
-
-    Args:
-        wires (int or Iterable[Number, str]): Number of subsystems represented by the device, or iterable of unique labels for the subsystems.
-        gateset (str): Target gateset, either "qis" or "native".
-        shots (int): Number of circuit evaluations/random samples used to estimate expectation values and variances of observables.
-        api_key (str): The IonQ API key. If not provided, the environment
-            variable ``IONQ_API_KEY`` is used.
-    """
-
-    def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
-        super().__init__(
-            wires,
-            target="qpu",
-            backend="aria-1",
-            gateset=gateset,
-            shots=shots,
-            api_key=api_key,
-        )
-
-
-class Aria2QPUDevice(QPUDevice):
-    """
-    PennyLane device for the IonQ Aria-2 QPU backend.
-
-    Args:
-        wires (int or Iterable[Number, str]): Number of subsystems represented by the device, or iterable of unique labels for the subsystems.
-        gateset (str): Target gateset, either "qis" or "native".
-        shots (int): Number of circuit evaluations/random samples used to estimate expectation values and variances of observables.
-        api_key (str): The IonQ API key. If not provided, the environment
-            variable ``IONQ_API_KEY`` is used.
-    """
-
-    def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
-        super().__init__(
-            wires,
-            target="qpu",
-            backend="aria-2",
-            gateset=gateset,
-            shots=shots,
-            api_key=api_key,
-        )
-
-
-class Forte1QPUDevice(QPUDevice):
-    """
-    PennyLane device for the IonQ Forte-1 QPU backend.
-
-    Args:
-        wires (int or Iterable[Number, str]): Number of subsystems represented by the device, or iterable of unique labels for the subsystems.
-        gateset (str): Target gateset, either "qis" or "native".
-        shots (int): Number of circuit evaluations/random samples used to estimate expectation values and variances of observables.
-        api_key (str): The IonQ API key. If not provided, the environment
-            variable ``IONQ_API_KEY`` is used.
-    """
-
-    def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
-        super().__init__(
-            wires,
-            target="qpu",
-            backend="forte-1",
-            gateset=gateset,
-            shots=shots,
-            api_key=api_key,
-        )

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -333,6 +333,17 @@ class QPUDevice(IonQDevice):
 
 
 class HarmonyQPUDevice(QPUDevice):
+    """
+    PennyLane device for the IonQ Harmony QPU backend.
+
+    Args:
+        wires (int or Iterable[Number, str]): Number of subsystems represented by the device, or iterable of unique labels for the subsystems.
+        gateset (str): Target gateset, either "qis" or "native".
+        shots (int): Number of circuit evaluations/random samples used to estimate expectation values and variances of observables.
+        api_key (str): The IonQ API key. If not provided, the environment
+            variable ``IONQ_API_KEY`` is used.
+    """
+
     def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
         super().__init__(
             wires,
@@ -345,6 +356,17 @@ class HarmonyQPUDevice(QPUDevice):
 
 
 class Aria1QPUDevice(QPUDevice):
+    """
+    PennyLane device for the IonQ Aria-1 QPU backend.
+
+    Args:
+        wires (int or Iterable[Number, str]): Number of subsystems represented by the device, or iterable of unique labels for the subsystems.
+        gateset (str): Target gateset, either "qis" or "native".
+        shots (int): Number of circuit evaluations/random samples used to estimate expectation values and variances of observables.
+        api_key (str): The IonQ API key. If not provided, the environment
+            variable ``IONQ_API_KEY`` is used.
+    """
+
     def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
         super().__init__(
             wires,
@@ -357,6 +379,17 @@ class Aria1QPUDevice(QPUDevice):
 
 
 class Aria2QPUDevice(QPUDevice):
+    """
+    PennyLane device for the IonQ Aria-2 QPU backend.
+
+    Args:
+        wires (int or Iterable[Number, str]): Number of subsystems represented by the device, or iterable of unique labels for the subsystems.
+        gateset (str): Target gateset, either "qis" or "native".
+        shots (int): Number of circuit evaluations/random samples used to estimate expectation values and variances of observables.
+        api_key (str): The IonQ API key. If not provided, the environment
+            variable ``IONQ_API_KEY`` is used.
+    """
+
     def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
         super().__init__(
             wires,
@@ -369,6 +402,17 @@ class Aria2QPUDevice(QPUDevice):
 
 
 class Forte1QPUDevice(QPUDevice):
+    """
+    PennyLane device for the IonQ Forte-1 QPU backend.
+
+    Args:
+        wires (int or Iterable[Number, str]): Number of subsystems represented by the device, or iterable of unique labels for the subsystems.
+        gateset (str): Target gateset, either "qis" or "native".
+        shots (int): Number of circuit evaluations/random samples used to estimate expectation values and variances of observables.
+        api_key (str): The IonQ API key. If not provided, the environment
+            variable ``IONQ_API_KEY`` is used.
+    """
+
     def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
         super().__init__(
             wires,

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -91,13 +91,9 @@ class IonQDevice(QubitDevice):
     # and therefore does not support the Hermitian observable.
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Identity"}
 
-    def __init__(
-        self, wires, *, target="simulator", gateset="qis", shots=1024, api_key=None
-    ):
+    def __init__(self, wires, *, target="simulator", gateset="qis", shots=1024, api_key=None):
         if shots is None:
-            raise ValueError(
-                "The ionq device does not support analytic expectation values."
-            )
+            raise ValueError("The ionq device does not support analytic expectation values.")
 
         super().__init__(wires=wires, shots=shots)
         self.target = target
@@ -136,9 +132,7 @@ class IonQDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         if len(operations) == 0 and len(rotations) == 0:
-            warnings.warn(
-                "Circuit is empty. Empty circuits return failures. Submitting anyway."
-            )
+            warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
 
         for i, operation in enumerate(operations):
             if i > 0 and operation.name in {
@@ -218,8 +212,7 @@ class IonQDevice(QubitDevice):
             # Here, we rearrange the states to match the big-endian ordering
             # expected by PennyLane.
             basis_states = (
-                int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2)
-                for k in self.histogram
+                int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2) for k in self.histogram
             )
             idx = np.fromiter(basis_states, dtype=int)
 
@@ -239,9 +232,7 @@ class IonQDevice(QubitDevice):
         if shot_range is None and bin_size is None:
             return self.marginal_prob(self.prob, wires)
 
-        return self.estimate_probability(
-            wires=wires, shot_range=shot_range, bin_size=bin_size
-        )
+        return self.estimate_probability(wires=wires, shot_range=shot_range, bin_size=bin_size)
 
 
 class SimulatorDevice(IonQDevice):
@@ -262,12 +253,8 @@ class SimulatorDevice(IonQDevice):
     name = "IonQ Simulator PennyLane plugin"
     short_name = "ionq.simulator"
 
-    def __init__(
-        self, wires, *, target="simulator", gateset="qis", shots=1024, api_key=None
-    ):
-        super().__init__(
-            wires=wires, target=target, gateset=gateset, shots=shots, api_key=api_key
-        )
+    def __init__(self, wires, *, target="simulator", gateset="qis", shots=1024, api_key=None):
+        super().__init__(wires=wires, target=target, gateset=gateset, shots=shots, api_key=api_key)
 
     def generate_samples(self):
         """Generates samples by random sampling with the probabilities returned by the simulator."""

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -93,9 +93,13 @@ class IonQDevice(QubitDevice):
     # and therefore does not support the Hermitian observable.
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Identity"}
 
-    def __init__(self, wires, *, target="simulator", gateset="qis", shots=1024, api_key=None):
+    def __init__(
+        self, wires, *, target="simulator", gateset="qis", shots=1024, api_key=None
+    ):
         if shots is None:
-            raise ValueError("The ionq device does not support analytic expectation values.")
+            raise ValueError(
+                "The ionq device does not support analytic expectation values."
+            )
 
         super().__init__(wires=wires, shots=shots)
         self.target = target
@@ -134,7 +138,9 @@ class IonQDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         if len(operations) == 0 and len(rotations) == 0:
-            warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
+            warnings.warn(
+                "Circuit is empty. Empty circuits return failures. Submitting anyway."
+            )
 
         for i, operation in enumerate(operations):
             if i > 0 and operation.name in {"BasisState", "QubitStateVector"}:
@@ -210,7 +216,8 @@ class IonQDevice(QubitDevice):
             # Here, we rearrange the states to match the big-endian ordering
             # expected by PennyLane.
             basis_states = (
-                int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2) for k in self.histogram
+                int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2)
+                for k in self.histogram
             )
             idx = np.fromiter(basis_states, dtype=int)
 
@@ -230,7 +237,9 @@ class IonQDevice(QubitDevice):
         if shot_range is None and bin_size is None:
             return self.marginal_prob(self.prob, wires)
 
-        return self.estimate_probability(wires=wires, shot_range=shot_range, bin_size=bin_size)
+        return self.estimate_probability(
+            wires=wires, shot_range=shot_range, bin_size=bin_size
+        )
 
 
 class SimulatorDevice(IonQDevice):
@@ -251,8 +260,12 @@ class SimulatorDevice(IonQDevice):
     name = "IonQ Simulator PennyLane plugin"
     short_name = "ionq.simulator"
 
-    def __init__(self, wires, *, target="simulator", gateset="qis", shots=1024, api_key=None):
-        super().__init__(wires=wires, target=target, gateset=gateset, shots=shots, api_key=api_key)
+    def __init__(
+        self, wires, *, target="simulator", gateset="qis", shots=1024, api_key=None
+    ):
+        super().__init__(
+            wires=wires, target=target, gateset=gateset, shots=shots, api_key=api_key
+        )
 
     def generate_samples(self):
         """Generates samples by random sampling with the probabilities returned by the simulator."""
@@ -279,8 +292,20 @@ class QPUDevice(IonQDevice):
     name = "IonQ QPU PennyLane plugin"
     short_name = "ionq.qpu"
 
-    def __init__(self, wires, *, target="qpu", gateset="qis", shots=1024, api_key=None):
-        super().__init__(wires=wires, target=target, gateset=gateset, shots=shots, api_key=api_key)
+    def __init__(
+        self,
+        wires,
+        *,
+        target="qpu",
+        backend="",
+        gateset="qis",
+        shots=1024,
+        api_key=None,
+    ):
+        target += backend
+        super().__init__(
+            wires=wires, target=target, gateset=gateset, shots=shots, api_key=api_key
+        )
 
     def generate_samples(self):
         """Generates samples from the qpu.

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -309,7 +309,11 @@ class QPUDevice(IonQDevice):
         if self.backend is not None:
             target += "." + self.backend
         super().__init__(
-            wires=wires, target=target, gateset=gateset, shots=shots, api_key=api_key
+            wires=wires,
+            target=target,
+            gateset=gateset,
+            shots=shots,
+            api_key=api_key,
         )
 
     def generate_samples(self):

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -302,7 +302,7 @@ class QPUDevice(IonQDevice):
         shots=1024,
         api_key=None,
     ):
-        target += backend
+        target += "." + backend
         super().__init__(
             wires=wires, target=target, gateset=gateset, shots=shots, api_key=api_key
         )

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,10 @@ info = {
         "pennylane.plugins": [
             "ionq.simulator = pennylane_ionq:SimulatorDevice",
             "ionq.qpu = pennylane_ionq:QPUDevice",
+            "ionq.qpu.harmony = pennylane_ionq:HarmonyQPUDevice",
+            "ionq.qpu.aria-1 = pennylane_ionq:Aria1QPUDevice",
+            "ionq.qpu.aria-2 = pennylane_ionq:Aria2QPUDevice",
+            "ionq.qpu.forte-1 = pennylane_ionq:Forte1QPUDevice",
         ]
     },
     "description": "PennyLane plugin for IonQ",

--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,11 @@ info = {
     "maintainer_email": "software@xanadu.ai",
     "url": "http://xanadu.ai",
     "license": "Apache License 2.0",
-    "packages": [
-        "pennylane_ionq"
-    ],
+    "packages": ["pennylane_ionq"],
     "entry_points": {
         "pennylane.plugins": [
             "ionq.simulator = pennylane_ionq:SimulatorDevice",
-            "ionq.qpu = pennylane_ionq:QPUDevice"
+            "ionq.qpu = pennylane_ionq:QPUDevice",
         ]
     },
     "description": "PennyLane plugin for IonQ",

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,6 @@ info = {
         "pennylane.plugins": [
             "ionq.simulator = pennylane_ionq:SimulatorDevice",
             "ionq.qpu = pennylane_ionq:QPUDevice",
-            "ionq.qpu.harmony = pennylane_ionq:HarmonyQPUDevice",
-            "ionq.qpu.aria-1 = pennylane_ionq:Aria1QPUDevice",
-            "ionq.qpu.aria-2 = pennylane_ionq:Aria2QPUDevice",
-            "ionq.qpu.forte-1 = pennylane_ionq:Forte1QPUDevice",
         ]
     },
     "description": "PennyLane plugin for IonQ",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,14 @@ import os
 import numpy as np
 import pytest
 
-from pennylane_ionq import SimulatorDevice, QPUDevice
+from pennylane_ionq import (
+    SimulatorDevice,
+    QPUDevice,
+    HarmonyQPUDevice,
+    Aria1QPUDevice,
+    Aria2QPUDevice,
+    Forte1QPUDevice,
+)
 
 
 np.random.seed(42)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,14 @@ analytic_devices = []
 # List of all devices that do *not* support analytic expectation
 # value computation. This generally includes hardware devices
 # and hardware simulators.
-hw_devices = [SimulatorDevice]
+hw_devices = [
+    SimulatorDevice,
+    QPUDevice,
+    HarmonyQPUDevice,
+    Aria1QPUDevice,
+    Aria2QPUDevice,
+    Forte1QPUDevice,
+]
 
 # List of all device shortnames
 shortnames = [d.short_name for d in analytic_devices + hw_devices]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import numpy as np
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,17 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import numpy as np
 import pytest
 
-from pennylane_ionq import (
-    SimulatorDevice,
-    QPUDevice,
-    HarmonyQPUDevice,
-    Aria1QPUDevice,
-    Aria2QPUDevice,
-    Forte1QPUDevice,
-)
+from pennylane_ionq import SimulatorDevice, QPUDevice
 
 
 np.random.seed(42)
@@ -57,14 +51,7 @@ analytic_devices = []
 # List of all devices that do *not* support analytic expectation
 # value computation. This generally includes hardware devices
 # and hardware simulators.
-hw_devices = [
-    SimulatorDevice,
-    QPUDevice,
-    HarmonyQPUDevice,
-    Aria1QPUDevice,
-    Aria2QPUDevice,
-    Forte1QPUDevice,
-]
+hw_devices = [SimulatorDevice, QPUDevice]
 
 # List of all device shortnames
 shortnames = [d.short_name for d in analytic_devices + hw_devices]

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -181,6 +181,18 @@ class TestDeviceIntegration:
         dev = qml.device(d, wires=1, shots=1)
         assert dev.prob is None
 
+    @pytest.mark.parametrize(
+        "backend", ["harmony", "aria-1", "aria-2", "forte-1", None]
+    )
+    def test_backend_initialization(self, backend):
+        """Test that the device initializes with the correct backend."""
+        if backend:
+            dev = qml.device("ionq.qpu", wires=2, shots=1000, backend=backend)
+            assert dev.backend == backend
+        else:
+            dev = qml.device("ionq.qpu", wires=2, shots=1000)
+            assert dev.backend == None
+
 
 class TestJobAttribute:
     """Tests job creation with mocked submission."""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -187,7 +187,12 @@ class TestDeviceIntegration:
     def test_backend_initialization(self, backend):
         """Test that the device initializes with the correct backend."""
         if backend:
-            dev = qml.device("ionq.qpu", wires=2, shots=1000, backend=backend)
+            dev = qml.device(
+                "ionq.qpu",
+                wires=2,
+                shots=1000,
+                backend=backend,
+            )
             assert dev.backend == backend
         else:
             dev = qml.device("ionq.qpu", wires=2, shots=1000)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -96,7 +96,6 @@ class TestDeviceIntegration:
             dev.apply([])
 
     def test_failedcircuit(self, monkeypatch):
-
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
@@ -246,7 +245,7 @@ class TestJobAttribute:
             pass
 
         mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
-        dev = IonQDevice(wires=(0,1,2), gateset="native")
+        dev = IonQDevice(wires=(0, 1, 2), gateset="native")
 
         with qml.tape.QuantumTape() as tape:
             GPI(0.1, wires=[0])
@@ -275,6 +274,3 @@ class TestJobAttribute:
             "targets": [1, 2],
             "phases": [0.2, 0.3],
         }
-
-
-


### PR DESCRIPTION
use the new `backend` field:

```python
dev = qml.device(
    'ionq.qpu',
    backend='aria-1',
    api_key=api_key,
    wires=2,
)
```

to call `qpu.aria-1`