### PR TITLE
Update to codecov-action v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.12
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.codecov_token }}
           file: ./coverage.xml
 
   integration-tests:


### PR DESCRIPTION
This PR is required to update tests to use the latest version of the codecov action (v4.0.0)

More Context: [here](https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/)