### PR TITLE
Enable multi circuit submission in PennyLane IonQ, second attempt.

### DIFF
--- a/pennylane_ionq/_version.py
+++ b/pennylane_ionq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0"
+__version__ = "0.37.0"

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -27,22 +27,13 @@ from pennylane import QubitDevice, DeviceError
 from pennylane.measurements import (
     ClassicalShadowMP,
     CountsMP,
-    ExpectationMP,
-    MeasurementTransform,
-    MeasurementValue,
-    MutualInfoMP,
-    ProbabilityMP,
     SampleMeasurement,
     SampleMP,
     ShadowExpvalMP,
     Shots,
     StateMeasurement,
-    StateMP,
-    VarianceMP,
-    VnEntropyMP,
 )
 from pennylane.resource import Resources
-from pennylane.tape import QuantumTape
 
 from .api_client import Job, JobExecutionError
 from ._version import __version__

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -14,6 +14,9 @@
 """
 This module contains the device class for constructing IonQ devices for PennyLane.
 """
+import inspect
+import logging
+from typing import Union
 import warnings
 from time import sleep
 
@@ -21,8 +24,31 @@ import numpy as np
 
 from pennylane import QubitDevice, DeviceError
 
+from pennylane.measurements import (
+    ClassicalShadowMP,
+    CountsMP,
+    ExpectationMP,
+    MeasurementTransform,
+    MeasurementValue,
+    MutualInfoMP,
+    ProbabilityMP,
+    SampleMeasurement,
+    SampleMP,
+    ShadowExpvalMP,
+    Shots,
+    StateMeasurement,
+    StateMP,
+    VarianceMP,
+    VnEntropyMP,
+)
+from pennylane.resource import Resources
+from pennylane.tape import QuantumTape
+
 from .api_client import Job, JobExecutionError
 from ._version import __version__
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 _qis_operation_map = {
     # native PennyLane operations also native to IonQ
@@ -118,26 +144,39 @@ class IonQDevice(QubitDevice):
             raise ValueError("The ionq device does not support analytic expectation values.")
 
         super().__init__(wires=wires, shots=shots)
+        self._current_circuit_index = None
         self.target = target
         self.api_key = api_key
         self.gateset = gateset
         self.error_mitigation = error_mitigation
         self.sharpen = sharpen
         self._operation_map = _GATESET_OPS[gateset]
+        self.histogram = None
+        self.histograms = None
         self.reset()
 
-    def reset(self):
+    def reset(self, circuits_array_length=0):
         """Reset the device"""
-        self._prob_array = None
+        self._current_circuit_index = None
         self.histogram = None
-        self.circuit = {
-            "format": "ionq.circuit.v0",
-            "qubits": self.num_wires,
-            "circuit": [],
-            "gateset": self.gateset,
-        }
+        self.histograms = None
+        self._prob_array = None
+        if circuits_array_length == 0:
+            self.input = {
+                "format": "ionq.circuit.v0",
+                "qubits": self.num_wires,
+                "circuit": [],
+                "gateset": self.gateset,
+            }
+        else:
+            self.input = {
+                "format": "ionq.circuit.v0",
+                "qubits": self.num_wires,
+                "circuits": [{"circuit": []} for _ in range(circuits_array_length)],
+                "gateset": self.gateset,
+            }
         self.job = {
-            "input": self.circuit,
+            "input": self.input,
             "target": self.target,
             "shots": self.shots,
         }
@@ -150,6 +189,116 @@ class IonQDevice(QubitDevice):
                 UserWarning,
                 stacklevel=2,
             )
+
+    def batch_execute(self, circuits):
+        """Execute a batch of quantum circuits on the device.
+
+        The circuits are represented by tapes, and they are executed one-by-one using the
+        device's ``execute`` method. The results are collected in a list.
+
+        Args:
+            circuits (list[~.tape.QuantumTape]): circuits to execute on the device
+
+        Returns:
+            list[array[float]]: list of measured value(s)
+        """
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                """Entry with args=(circuits=%s) called by=%s""",
+                circuits,
+                "::L".join(
+                    str(i)
+                    for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]
+                ),
+            )
+
+        self.reset(circuits_array_length=len(circuits))
+
+        for circuit_index, circuit in enumerate(circuits):
+            self.check_validity(circuit.operations, circuit.observables)
+            self.batch_apply(
+                circuit.operations,
+                rotations=self._get_diagonalizing_gates(circuit),
+                circuit_index=circuit_index,
+            )
+
+        self._submit_job()
+
+        results = []
+        for circuit_index, circuit in enumerate(circuits):
+            self._current_circuit_index = circuit_index
+            sample_type = (SampleMP, CountsMP, ClassicalShadowMP, ShadowExpvalMP)
+            if self.shots is not None or any(
+                isinstance(m, sample_type) for m in circuit.measurements
+            ):
+                self._samples = self.generate_samples()
+
+            # compute the required statistics
+            if self._shot_vector is not None:
+                result = self.shot_vec_statistics(circuit)
+            else:
+                result = self.statistics(circuit)
+                single_measurement = len(circuit.measurements) == 1
+
+                result = result[0] if single_measurement else tuple(result)
+
+            self._current_circuit_index = None
+            self._samples = None
+            results.append(result)
+
+        # increment counter for number of executions of qubit device
+        self._num_executions += 1
+
+        if self.tracker.active:
+            for circuit in circuits:
+                shots_from_dev = (
+                    self._shots if not self.shot_vector else self._raw_shot_sequence
+                )
+                tape_resources = circuit.specs["resources"]
+
+                resources = Resources(  # temporary until shots get updated on tape !
+                    tape_resources.num_wires,
+                    tape_resources.num_gates,
+                    tape_resources.gate_types,
+                    tape_resources.gate_sizes,
+                    tape_resources.depth,
+                    Shots(shots_from_dev),
+                )
+                self.tracker.update(
+                    executions=1,
+                    shots=self._shots,
+                    results=results,
+                    resources=resources,
+                )
+
+            self.tracker.update(batches=1, batch_len=len(circuits))
+            self.tracker.record()
+
+        return results
+
+    def batch_apply(self, operations, circuit_index, **kwargs):
+
+        rotations = kwargs.pop("rotations", [])
+
+        if len(operations) == 0 and len(rotations) == 0:
+            warnings.warn(
+                "Circuit is empty. Empty circuits return failures. Submitting anyway."
+            )
+
+        for i, operation in enumerate(operations):
+            if i > 0 and operation.name in {
+                "BasisState",
+                "QubitStateVector",
+                "StatePrep",
+            }:
+                raise DeviceError(
+                    f"The operation {operation.name} is only supported at the beginning of a circuit."
+                )
+            self._apply_operation(operation, circuit_index)
+
+        # diagonalize observables
+        for operation in rotations:
+            self._apply_operation(operation, circuit_index)
 
     @property
     def operations(self):
@@ -184,7 +333,7 @@ class IonQDevice(QubitDevice):
 
         self._submit_job()
 
-    def _apply_operation(self, operation):
+    def _apply_operation(self, operation, circuit_index=None):
         name = operation.name
         wires = self.map_wires(operation.wires).tolist()
         gate = {"gate": self._operation_map[name]}
@@ -202,13 +351,18 @@ class IonQDevice(QubitDevice):
 
         if self.gateset == "native":
             if len(par) > 1:
-                gate["phases"] = [float(v) for v in par]
+                gate["phases"] = [float(v) for v in par[:2]]
+                if len(par) > 2:
+                    gate["angle"] = float(par[2])
             else:
                 gate["phase"] = float(par[0])
         elif par:
             gate["rotation"] = float(par[0])
 
-        self.circuit["circuit"].append(gate)
+        if "circuit" in self.input:
+            self.input["circuit"].append(gate)
+        else:
+            self.input["circuits"][circuit_index]["circuit"].append(gate)
 
     def _submit_job(self):
         job = Job(api_key=self.api_key)
@@ -232,13 +386,24 @@ class IonQDevice(QubitDevice):
         # state (as a base-10 integer string) to the probability
         # as a floating point value between 0 and 1.
         # e.g., {"0": 0.413, "9": 0.111, "17": 0.476}
-        self.histogram = job.data.value
+        some_inner_value = next(iter(job.data.value.values()))
+        if isinstance(some_inner_value, dict):
+            self.histograms = []
+            for key in job.data.value.keys():
+                self.histograms.append(job.data.value[key])
+        else:
+            self.histograms = []
+            self.histograms.append(job.data.value)
+            self.histogram = job.data.value
 
     @property
     def prob(self):
         """None or array[float]: Array of computational basis state probabilities. If
         no job has been submitted, returns ``None``.
         """
+        if self._current_circuit_index is not None:
+            self.histogram = self.histograms[self._current_circuit_index]
+
         if self.histogram is None:
             return None
 
@@ -259,6 +424,9 @@ class IonQDevice(QubitDevice):
             norm = sum(histogram_values)
             self._prob_array[idx] = np.fromiter(histogram_values, float) / norm
 
+        if self._current_circuit_index is not None:
+            self.histogram = None
+
         return self._prob_array
 
     def probability(self, wires=None, shot_range=None, bin_size=None):
@@ -269,6 +437,134 @@ class IonQDevice(QubitDevice):
 
         return self.estimate_probability(wires=wires, shot_range=shot_range, bin_size=bin_size)
 
+    def expval(self, observable, shot_range=None, bin_size=None):
+        """
+        Returns the expectation value of a Hamiltonian observable.
+        Overwrites the method in QubitDevice class to accomodate batch submission of circuits.
+        When invoking this method after submitting circuits using any other method than 
+        QubitDevice.execute() method, self_current_circuit_index and self._samples should be 
+        initialized using the circuit which is targeted out of  one or potentially several circuits submitted 
+        in a batch. This is likely not very good design but the alternative would be to create
+        huge amounts of code duplication with respect to the Pennylane base code.
+
+        Args:
+            observable (~.Observable): a PennyLane observable
+            shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
+                to use. If not specified, all samples are used.
+            bin_size (int): Divides the shot range into bins of size ``bin_size``, and
+                returns the measurement statistic separately over each bin. If not
+                provided, the entire shot range is treated as a single bin.
+
+        """
+        try:
+            return super().expval(observable, shot_range, bin_size)
+        except TypeError as e:
+            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method, self_current_circuit_index and self._samples should be initialized using the circuit which is targeted out of  one or potentially several circuits submitted in a batch.", *e.args)
+            raise
+
+    def estimate_probability(
+        self, wires=None, shot_range=None, bin_size=None
+    ):
+        """Return the estimated probability of each computational basis state
+        using the generated samples. Overwrites the method in QubitDevice class
+        to accomodate batch submission of circuits. When invoking this method after 
+        submitting circuits using any other method than QubitDevice.execute() 
+        method, self_current_circuit_index and self._samples should be initialized to the 
+        circuit which is targeted out of  one or potentially several circuits submitted in a batch.
+        This is likely not very good design but the alternative would be to create
+        huge amounts of code duplication with respect to the Pennylane base code.
+
+        Args:
+            wires (Iterable[Number, str], Number, str, Wires): wires to calculate
+                marginal probabilities for. Wires not provided are traced out of  one or the system.
+            shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
+                to use. If not specified, all samples are used.
+            bin_size (int): Divides the shot range into bins of size ``bin_size``, and
+                returns the measurement statistic separately over each bin. If not
+                provided, the entire shot range is treated as a single bin.
+
+        Returns:
+            array[float]: list of the probabilities
+        """
+        try:
+            return super().estimate_probability(wires, shot_range, bin_size)
+        except TypeError as e:
+            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method, self_current_circuit_index and self._samples should be initialized using the circuit which is targeted out of  one or potentially several circuits submitted in a batch.", *e.args)
+            raise
+
+    def sample(
+        self,
+        observable,
+        shot_range=None,
+        bin_size=None,
+        counts=False,
+    ):
+        """Return samples of an observable. Overwrites the method in QubitDevice class
+        to accomodate batch submission of circuits. When invoking this method after submitting 
+        circuits using any other method than QubitDevice.execute() method, 
+        self_current_circuit_index and self._samples should be initialized using the circuit which 
+        is targeted out of  one or potentially several circuits submitted in a batch.
+        This is likely not very good design but the alternative would be to create
+        huge amounts of code duplication with respect to the Pennylane base code.
+
+        Args:
+            observable (Observable): the observable to sample
+            shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
+                to use. If not specified, all samples are used.
+            bin_size (int): Divides the shot range into bins of size ``bin_size``, and
+                returns the measurement statistic separately over each bin. If not
+                provided, the entire shot range is treated as a single bin.
+            counts (bool): whether counts (``True``) or raw samples (``False``)
+                should be returned
+            circuit_index (int): index of circuit in case of batch circuit submission
+
+        Raises:
+            EigvalsUndefinedError: if no information is available about the
+                eigenvalues of the observable
+
+        Returns:
+            Union[array[float], dict, list[dict]]: samples in an array of
+            dimension ``(shots,)`` or counts
+        """
+        try:
+            return super().sample(observable, shot_range, bin_size, counts)
+        except TypeError as e:
+            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method self_current_circuit_index and self._samples should be initialized using the circuit which is targeted out of  one or potentially several circuits submitted in a batch.", *e.args)
+            raise
+
+    def _measure(
+        self,
+        measurement: Union[SampleMeasurement, StateMeasurement],
+        shot_range=None,
+        bin_size=None,
+    ):
+        """Compute the corresponding measurement process depending on ``shots`` and the measurement
+        type. Overwrites the method in QubitDevice class to accomodate batch submission of circuits.
+        When invoking this method after submitting circuits using any other method than QubitDevice.execute() 
+        method, self_current_circuit_index and self._samples should be initialized using the circuit which 
+        is targeted out of  one or potentially several circuits submitted in a batch. This is likely not very good 
+        design but the alternative would be to create huge amounts of code duplication with respect to the 
+        Pennylane base code.
+
+        Args:
+            measurement (Union[SampleMeasurement, StateMeasurement]): measurement process
+            shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
+                to use. If not specified, all samples are used.
+            bin_size (int): Divides the shot range into bins of size ``bin_size``, and
+                returns the measurement statistic separately over each bin. If not
+                provided, the entire shot range is treated as a single bin.
+
+        Raises:
+            ValueError: if the measurement cannot be computed
+
+        Returns:
+            Union[float, dict, list[float]]: result of the measurement
+        """
+        try:
+            return super()._measure(measurement, shot_range, bin_size)
+        except TypeError as e:
+            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method, self_current_circuit_index and self._samples should be initialized using the circuit which is targeted out of  one or potentially several circuits submitted in a batch. ", *e.args)
+            raise
 
 class SimulatorDevice(IonQDevice):
     r"""Simulator device for IonQ.

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -433,9 +433,9 @@ class IonQDevice(QubitDevice):
         Returns the expectation value of a Hamiltonian observable.
         Overwrites the method in QubitDevice class to accomodate batch submission of circuits.
         When invoking this method after submitting circuits using any other method than 
-        QubitDevice.execute() method, self_current_circuit_index and self._samples should be 
-        initialized using the circuit which is targeted out of  one or potentially several circuits submitted 
-        in a batch. This is likely not very good design but the alternative would be to create
+        QubitDevice.execute() method, self_current_circuit_index should be 
+        initialized pointing to the circuit which is targeted out of one or potentially several circuits submitted 
+        in a batch. This is not very good design but the alternative would be to create
         huge amounts of code duplication with respect to the Pennylane base code.
 
         Args:
@@ -448,9 +448,13 @@ class IonQDevice(QubitDevice):
 
         """
         try:
-            return super().expval(observable, shot_range, bin_size)
+            self._samples = self.generate_samples()
+            result = super().expval(observable, shot_range, bin_size)
+            self._samples = None
+            return result
         except TypeError as e:
-            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method, self_current_circuit_index and self._samples should be initialized using the circuit which is targeted out of  one or potentially several circuits submitted in a batch.", *e.args)
+            self._samples = None
+            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method, self_current_circuit_index should be initialized pointing to the circuit which is targeted out of one or potentially several circuits submitted in a batch.", *e.args)
             raise
 
     def estimate_probability(
@@ -460,14 +464,14 @@ class IonQDevice(QubitDevice):
         using the generated samples. Overwrites the method in QubitDevice class
         to accomodate batch submission of circuits. When invoking this method after 
         submitting circuits using any other method than QubitDevice.execute() 
-        method, self_current_circuit_index and self._samples should be initialized to the 
-        circuit which is targeted out of  one or potentially several circuits submitted in a batch.
-        This is likely not very good design but the alternative would be to create
+        method, self_current_circuit_index should be initialized to the 
+        circuit which is targeted out of one or potentially several circuits submitted in a batch.
+        This is not very good design but the alternative would be to create
         huge amounts of code duplication with respect to the Pennylane base code.
 
         Args:
             wires (Iterable[Number, str], Number, str, Wires): wires to calculate
-                marginal probabilities for. Wires not provided are traced out of  one or the system.
+                marginal probabilities for. Wires not provided are traced out of one or the system.
             shot_range (tuple[int]): 2-tuple of integers specifying the range of samples
                 to use. If not specified, all samples are used.
             bin_size (int): Divides the shot range into bins of size ``bin_size``, and
@@ -478,9 +482,13 @@ class IonQDevice(QubitDevice):
             array[float]: list of the probabilities
         """
         try:
-            return super().estimate_probability(wires, shot_range, bin_size)
+            self._samples = self.generate_samples()
+            result = super().estimate_probability(wires, shot_range, bin_size)
+            self._samples = None
+            return result
         except TypeError as e:
-            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method, self_current_circuit_index and self._samples should be initialized using the circuit which is targeted out of  one or potentially several circuits submitted in a batch.", *e.args)
+            self._samples = None
+            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method, self_current_circuit_index should be initialized pointing to the circuit which is targeted out of one or potentially several circuits submitted in a batch.", *e.args)
             raise
 
     def sample(
@@ -493,9 +501,9 @@ class IonQDevice(QubitDevice):
         """Return samples of an observable. Overwrites the method in QubitDevice class
         to accomodate batch submission of circuits. When invoking this method after submitting 
         circuits using any other method than QubitDevice.execute() method, 
-        self_current_circuit_index and self._samples should be initialized using the circuit which 
-        is targeted out of  one or potentially several circuits submitted in a batch.
-        This is likely not very good design but the alternative would be to create
+        self_current_circuit_index should be initialized pointing to the circuit which 
+        is targeted out of one or potentially several circuits submitted in a batch.
+        This is not very good design but the alternative would be to create
         huge amounts of code duplication with respect to the Pennylane base code.
 
         Args:
@@ -518,9 +526,13 @@ class IonQDevice(QubitDevice):
             dimension ``(shots,)`` or counts
         """
         try:
-            return super().sample(observable, shot_range, bin_size, counts)
+            self._samples = self.generate_samples()
+            result = super().sample(observable, shot_range, bin_size, counts)
+            self._samples = None
+            return result
         except TypeError as e:
-            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method self_current_circuit_index and self._samples should be initialized using the circuit which is targeted out of  one or potentially several circuits submitted in a batch.", *e.args)
+            self._samples = None
+            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method self_current_circuit_index should be initialized pointing to the circuit which is targeted out of one or potentially several circuits submitted in a batch.", *e.args)
             raise
 
     def _measure(
@@ -532,8 +544,8 @@ class IonQDevice(QubitDevice):
         """Compute the corresponding measurement process depending on ``shots`` and the measurement
         type. Overwrites the method in QubitDevice class to accomodate batch submission of circuits.
         When invoking this method after submitting circuits using any other method than QubitDevice.execute() 
-        method, self_current_circuit_index and self._samples should be initialized using the circuit which 
-        is targeted out of  one or potentially several circuits submitted in a batch. This is likely not very good 
+        method, self_current_circuit_index should be initialized pointing to the circuit which 
+        is targeted out of one or potentially several circuits submitted in a batch. This is not very good 
         design but the alternative would be to create huge amounts of code duplication with respect to the 
         Pennylane base code.
 
@@ -552,9 +564,13 @@ class IonQDevice(QubitDevice):
             Union[float, dict, list[float]]: result of the measurement
         """
         try:
-            return super()._measure(measurement, shot_range, bin_size)
+            self._samples = self.generate_samples()
+            result = super()._measure(measurement, shot_range, bin_size)
+            self._samples = None
+            return result
         except TypeError as e:
-            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method, self_current_circuit_index and self._samples should be initialized using the circuit which is targeted out of  one or potentially several circuits submitted in a batch. ", *e.args)
+            self._samples = None
+            e.args = ("When invoking this method after submitting circuits using any other method than QubitDevice.execute() method, self_current_circuit_index should be initialized pointing to the circuit which is targeted out of one or potentially several circuits submitted in a batch. ", *e.args)
             raise
 
 class SimulatorDevice(IonQDevice):


### PR DESCRIPTION
Enable multi circuit submission. This is a second attempt to implement this functionality because the first implementation involved a lot of code duplication with respect to the PennyLane baseline code.