### PR TITLE
`QubitDevice` is now imported from `pennylane.devices`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ company offering access to quantum computing devices over the cloud.
 
 .. header-end-inclusion-marker-do-not-remove
 
-The plugin documentation can be found `here <https://pennylane-ionq.readthedocs.io/en/latest/>`__.
+The plugin documentation can be found `here <https://docs.pennylane.ai/projects/ionq>`__.
 
 Features
 ========

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -16,8 +16,8 @@ networkx==2.6.0
 ninja==1.10.2.3
 numpy==1.22.4
 packaging>22.0
-PennyLane==0.24.0
-PennyLane-Lightning==0.24.0
+PennyLane
+PennyLane-Lightning
 Pygments==2.15.0
 pyparsing==3.0.9
 python-dateutil==2.8.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,7 +15,7 @@ MarkupSafe==2.1.1
 networkx==2.6.0
 ninja==1.10.2.3
 numpy==1.22.4
-packaging==21.3
+packaging>22.0
 PennyLane==0.24.0
 PennyLane-Lightning==0.24.0
 Pygments==2.15.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 appdirs==1.4.4
 autograd==1.4
-autoray==0.3.2
+autoray
 Babel==2.10.3
 cachetools==5.2.0
 certifi==2023.7.22

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -19,7 +19,8 @@ from time import sleep
 
 import numpy as np
 
-from pennylane import QubitDevice, DeviceError
+from pennylane import DeviceError
+from pennylane.devices import QubitDevice
 
 from .api_client import Job, JobExecutionError
 from ._version import __version__


### PR DESCRIPTION
`pennylane.QubitDevice` is deprecated in v0.39, importing `QubitDevice` from `pennylane.devices` instead.