### PR TITLE
add a noise_model arg to device class

### DIFF
--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -139,7 +139,7 @@ class IonQDevice(QubitDevice):
         api_key=None,
         error_mitigation=None,
         sharpen=False,
-    ):
+    ):  # pylint: disable=too-many-arguments
         if shots is None:
             raise ValueError("The ionq device does not support analytic expectation values.")
 
@@ -445,7 +445,9 @@ class SimulatorDevice(IonQDevice):
     name = "IonQ Simulator PennyLane plugin"
     short_name = "ionq.simulator"
 
-    def __init__(self, wires, *, noise_model="ideal", gateset="qis", shots=1024, api_key=None):
+    def __init__(
+            self, wires, *, noise_model="ideal", gateset="qis", shots=1024, api_key=None
+        ):  # pylint: disable=too-many-arguments
         super().__init__(
             wires=wires,
             target="simulator",

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -93,6 +93,7 @@ class IonQDevice(QubitDevice):
 
     Kwargs:
         target (str): the target device, either ``"simulator"`` or ``"qpu"``. Defaults to ``simulator``.
+        noise_model (str): the qpu's noise model. Defaults to ``None``.
         gateset (str): the target gateset, either ``"qis"`` or ``"native"``. Defaults to ``qis``.
         shots (int, list[int]): Number of circuit evaluations/random samples used to estimate
             expectation values of observables. Defaults to 1024.
@@ -132,6 +133,7 @@ class IonQDevice(QubitDevice):
         wires,
         *,
         target="simulator",
+        noise_model=None,
         gateset="qis",
         shots=1024,
         api_key=None,
@@ -145,6 +147,7 @@ class IonQDevice(QubitDevice):
         self._current_circuit_index = None
         self.target = target
         self.api_key = api_key
+        self.noise_model = noise_model
         self.gateset = gateset
         self.error_mitigation = error_mitigation
         self.sharpen = sharpen
@@ -169,6 +172,8 @@ class IonQDevice(QubitDevice):
             "target": self.target,
             "shots": self.shots,
         }
+        if self.noise_model is not None:
+            self.job["noise_model"] = self.noise_model
         if self.error_mitigation is not None:
             self.job["error_mitigation"] = self.error_mitigation
         if self.job["target"] == "qpu":
@@ -422,6 +427,7 @@ class SimulatorDevice(IonQDevice):
         wires (int or Iterable[Number, str]]): Number of wires to initialize the device with,
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['ancilla', 'q1', 'q2']``).
+        noise_model (str): the qpu's noise model. Defaults to ``"ideal"``.
         gateset (str): the target gateset, either ``"qis"`` or ``"native"``. Defaults to ``qis``.
         shots (int, list[int], None): Number of circuit evaluations/random samples used to estimate
             expectation values of observables. If ``None``, the device calculates probability, expectation values,
@@ -435,10 +441,11 @@ class SimulatorDevice(IonQDevice):
     name = "IonQ Simulator PennyLane plugin"
     short_name = "ionq.simulator"
 
-    def __init__(self, wires, *, gateset="qis", shots=1024, api_key=None):
+    def __init__(self, wires, *, noise_model="ideal", gateset="qis", shots=1024, api_key=None):
         super().__init__(
             wires=wires,
             target="simulator",
+            noise_model=noise_model,
             gateset=gateset,
             shots=shots,
             api_key=api_key,

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -147,10 +147,14 @@ class IonQDevice(QubitDevice):
         self._current_circuit_index = None
         self.target = target
         self.api_key = api_key
-        self.noise_model = noise_model
         self.gateset = gateset
         self.error_mitigation = error_mitigation
         self.sharpen = sharpen
+        if target != "simulator" and noise_model is not None:
+            warnings.warn("Noise model is only supported for the simulator target.", UserWarning)
+            self.noise_model = None
+        else:
+            self.noise_model = noise_model
         self._operation_map = _GATESET_OPS[gateset]
         self.histograms = []
         self._samples = None
@@ -173,7 +177,7 @@ class IonQDevice(QubitDevice):
             "shots": self.shots,
         }
         if self.noise_model is not None:
-            self.job["noise_model"] = self.noise_model
+            self.job["noise"] = {"model": self.noise_model}
         if self.error_mitigation is not None:
             self.job["error_mitigation"] = self.error_mitigation
         if self.job["target"] == "qpu":

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -128,7 +128,7 @@ class IonQDevice(QubitDevice):
     # and therefore does not support the Hermitian observable.
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Identity", "Prod"}
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         wires,
         *,
@@ -139,7 +139,7 @@ class IonQDevice(QubitDevice):
         api_key=None,
         error_mitigation=None,
         sharpen=False,
-    ):  # pylint: disable=too-many-arguments
+    ):
         if shots is None:
             raise ValueError("The ionq device does not support analytic expectation values.")
 
@@ -445,9 +445,9 @@ class SimulatorDevice(IonQDevice):
     name = "IonQ Simulator PennyLane plugin"
     short_name = "ionq.simulator"
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
             self, wires, *, noise_model="ideal", gateset="qis", shots=1024, api_key=None
-        ):  # pylint: disable=too-many-arguments
+        ):
         super().__init__(
             wires=wires,
             target="simulator",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -468,7 +468,7 @@ you want to access must be first set via the set_current_circuit_index device me
     def test_default_noise_model(self, requires_api):
         """Test that the default noise model is correctly set."""
         dev = SimulatorDevice(wires=(0,))
-        assert dev.noise_model == "ideal"
+        assert dev.job["input"]["noise"]["model"] == "ideal"
 
 class TestJobAttribute:
     """Tests job creation with mocked submission."""
@@ -731,4 +731,4 @@ class TestJobAttribute:
 
         dev.apply(tape.operations)
 
-        assert dev.job["noise"]["model"] == "forte-1"
+        assert dev.job["input"]["noise"]["model"] == "forte-1"


### PR DESCRIPTION
WIP: add a noise_model argument that is either `ideal`, `harmony`, `aria-1`, or `forte-1` to the device class

```python
dev = IonQDevice(wires=(0,), target="simulator", noise_model="forte-1")

dev = SimulatorDevice(wires=(0,))  # noise_model defaults to "ideal"
```