### PR TITLE
Add new IonQ forte-enterprise backend names to tests.

### DIFF
--- a/doc/devices.rst
+++ b/doc/devices.rst
@@ -46,7 +46,7 @@ installed, you can use this device directly in PennyLane by specifying ``"ionq.q
     import pennylane as qml
     from pennylane_ionq import ops
 
-    dev = qml.device("ionq.qpu", backend="harmony", wires=2)
+    dev = qml.device("ionq.qpu", backend="aria-1", wires=2)
 
     @qml.qnode(dev)
     def circuit(x, y):

--- a/pennylane_ionq/_version.py
+++ b/pennylane_ionq/_version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Version information.
-   Version number (major.minor.patch[-label])
+Version number (major.minor.patch[-label])
 """
 
 __version__ = "0.40.0-dev"

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -172,9 +172,9 @@ class IonQDevice(QubitDevice):
         if self.error_mitigation is not None:
             self.job["error_mitigation"] = self.error_mitigation
         if self.job["target"] == "qpu":
-            self.job["target"] = "qpu.harmony"
+            self.job["target"] = "qpu.aria-1"
             warnings.warn(
-                "The ionq_qpu backend is deprecated. Defaulting to ionq_qpu.harmony.",
+                "The ionq_qpu backend is deprecated. Defaulting to ionq_qpu.aria-1.",
                 UserWarning,
                 stacklevel=2,
             )
@@ -459,8 +459,8 @@ class QPUDevice(IonQDevice):
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['ancilla', 'q1', 'q2']``).
         gateset (str): the target gateset, either ``"qis"`` or ``"native"``. Defaults to ``qis``.
-        backend (str): Optional specifier for an IonQ backend. Can be ``"harmony"``, ``"aria-1"``, etc.
-            Default to ``harmony``.
+        backend (str): Optional specifier for an IonQ backend. Can be ``"aria-1"``, ``"aria-2"``, etc.
+            Default to ``aria-1``.
         shots (int, list[int]): Number of circuit evaluations/random samples used to estimate
             expectation values of observables. Defaults to 1024. If a list of integers is passed, the
             circuit evaluations are batched over the list of shots.
@@ -486,7 +486,7 @@ class QPUDevice(IonQDevice):
         *,
         gateset="qis",
         shots=1024,
-        backend="harmony",
+        backend="aria-1",
         error_mitigation=None,
         sharpen=None,
         api_key=None,

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -266,7 +266,6 @@ class IonQDevice(QubitDevice):
         return results
 
     def batch_apply(self, operations, circuit_index, **kwargs):
-
         "Apply circuit operations when submitting for execution a batch of circuits."
 
         rotations = kwargs.pop("rotations", [])

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -127,6 +127,7 @@ class IonQDevice(QubitDevice):
     # and therefore does not support the Hermitian observable.
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Identity", "Prod"}
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         wires,
@@ -479,6 +480,7 @@ class QPUDevice(IonQDevice):
     name = "IonQ QPU PennyLane plugin"
     short_name = "ionq.qpu"
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         wires,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -218,7 +218,7 @@ class TestDeviceIntegration:
         dev = qml.device(d, wires=1, shots=1)
         assert dev.prob is None
 
-    @pytest.mark.parametrize("backend", ["harmony", "aria-1", "aria-2", "forte-1", None])
+    @pytest.mark.parametrize("backend", ["harmony", "aria-1", "aria-2", "forte-1", "forte-enterprise-1", "forte-enterprise-2", None])
     def test_backend_initialization(self, backend):
         """Test that the device initializes with the correct backend."""
         dev = qml.device(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -218,7 +218,17 @@ class TestDeviceIntegration:
         dev = qml.device(d, wires=1, shots=1)
         assert dev.prob is None
 
-    @pytest.mark.parametrize("backend", ["harmony", "aria-1", "aria-2", "forte-1", "forte-enterprise-1", "forte-enterprise-2", None])
+    @pytest.mark.parametrize("backend",
+        [
+            "harmony",
+            "aria-1",
+            "aria-2",
+            "forte-1",
+            "forte-enterprise-1",
+            "forte-enterprise-2",
+            None
+        ]
+    )
     def test_backend_initialization(self, backend):
         """Test that the device initializes with the correct backend."""
         dev = qml.device(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -220,7 +220,6 @@ class TestDeviceIntegration:
 
     @pytest.mark.parametrize("backend",
         [
-            "harmony",
             "aria-1",
             "aria-2",
             "forte-1",


### PR DESCRIPTION
Add new IonQ forte-enterprise backend names to tests. Use aria backend instead of harmony as default backend since harmony has been retired.