### PR TITLE
Updating `setuptools`

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,22 +5,9 @@ on:
 jobs:
   black:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
-        with:
-          access_token: ${{ github.token }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-
-      - name: Install dependencies
-        run: pip install black
-
-      - uses: actions/checkout@v2
-
-      - name: Run Black
-        run: black -l 100 pennylane_ionq/ --check
+    - uses: actions/checkout@v1
+    - name: Black Code Formatter
+      uses: lgeiger/black-action@master
+      with:
+        args: "-l 100 pennylane_ionq/ --check"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,9 +5,22 @@ on:
 jobs:
   black:
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Black Code Formatter
-      uses: lgeiger/black-action@master
-      with:
-        args: "-l 100 pennylane_ionq/ --check"
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install black
+
+      - uses: actions/checkout@v2
+
+      - name: Run Black
+        run: black -l 100 pennylane_ionq/ --check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,14 +24,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip setuptools>=75.8.1
           pip install -r requirements.txt
           pip install --upgrade git+https://github.com/PennyLaneAI/pennylane.git#egg=pennylane
           pip install wheel pytest pytest-cov pytest-mock pytest-benchmark --upgrade
       - name: Install Plugin
         run: |
           python setup.py bdist_wheel
-          pip install dist/PennyLane*.whl
+          pip install dist/pennylane*.whl
       - name: Run tests
         run: python -m pytest tests --cov=pennylane_ionq --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
         env:
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools>=75.8.1
           pip install -r requirements.txt
           pip install --upgrade git+https://github.com/PennyLaneAI/pennylane.git#egg=pennylane
           pip install wheel pytest pytest-benchmark pytest-cov pytest-mock flaky --upgrade
@@ -69,7 +69,7 @@ jobs:
       - name: Install Plugin
         run: |
           python setup.py bdist_wheel
-          pip install dist/PennyLane*.whl
+          pip install dist/pennylane*.whl
 
       - name: Run tests
         env:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -16,9 +16,9 @@ jobs:
 
       - name: Build and install Plugin
         run: |
-          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade pip wheel setuptools>=75.8.1
           python setup.py bdist_wheel
-          pip install dist/PennyLane*.whl
+          pip install dist/pennylane*.whl
 
       - name: Install test dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,16 @@
 
 ### Bug fixes 🐛
 
+### Internal changes
+
+* Pinning `setuptools` in the CI to update how the plugin is installed.
+  [(#133)](https://github.com/PennyLaneAI/pennylane-cirq/pull/133)
+
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Pietropaolo Frisoni
 
 ---
 # Release 0.39.0

--- a/pennylane_ionq/_version.py
+++ b/pennylane_ionq/_version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Version information.
-   Version number (major.minor.patch[-label])
+Version number (major.minor.patch[-label])
 """
 
 __version__ = "0.40.0-dev"

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -139,7 +139,9 @@ class IonQDevice(QubitDevice):
         sharpen=False,
     ):
         if shots is None:
-            raise ValueError("The ionq device does not support analytic expectation values.")
+            raise ValueError(
+                "The ionq device does not support analytic expectation values."
+            )
 
         super().__init__(wires=wires, shots=shots)
         self._current_circuit_index = None
@@ -203,7 +205,8 @@ class IonQDevice(QubitDevice):
                 """Entry with args=(circuits=%s) called by=%s""",
                 circuits,
                 "::L".join(
-                    str(i) for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]
+                    str(i)
+                    for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]
                 ),
             )
 
@@ -242,7 +245,9 @@ class IonQDevice(QubitDevice):
 
         if self.tracker.active:
             for circuit in circuits:
-                shots_from_dev = self._shots if not self.shot_vector else self._raw_shot_sequence
+                shots_from_dev = (
+                    self._shots if not self.shot_vector else self._raw_shot_sequence
+                )
                 tape_resources = circuit.specs["resources"]
 
                 resources = Resources(  # temporary until shots get updated on tape !
@@ -272,7 +277,9 @@ class IonQDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         if len(operations) == 0 and len(rotations) == 0:
-            warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
+            warnings.warn(
+                "Circuit is empty. Empty circuits return failures. Submitting anyway."
+            )
 
         for i, operation in enumerate(operations):
             self._apply_operation(operation, circuit_index)
@@ -297,7 +304,9 @@ class IonQDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         if len(operations) == 0 and len(rotations) == 0:
-            warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
+            warnings.warn(
+                "Circuit is empty. Empty circuits return failures. Submitting anyway."
+            )
 
         for i, operation in enumerate(operations):
             self._apply_operation(operation)
@@ -393,7 +402,9 @@ class IonQDevice(QubitDevice):
         # The IonQ API returns basis states using little-endian ordering.
         # Here, we rearrange the states to match the big-endian ordering
         # expected by PennyLane.
-        basis_states = (int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2) for k in histogram)
+        basis_states = (
+            int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2) for k in histogram
+        )
         idx = np.fromiter(basis_states, dtype=int)
 
         # convert the sparse probs into a probability array
@@ -412,7 +423,9 @@ class IonQDevice(QubitDevice):
         if shot_range is None and bin_size is None:
             return self.marginal_prob(self.prob, wires)
 
-        return self.estimate_probability(wires=wires, shot_range=shot_range, bin_size=bin_size)
+        return self.estimate_probability(
+            wires=wires, shot_range=shot_range, bin_size=bin_size
+        )
 
 
 class SimulatorDevice(IonQDevice):

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -271,7 +271,6 @@ class IonQDevice(QubitDevice):
         return results
 
     def batch_apply(self, operations, circuit_index, **kwargs):
-
         "Apply circuit operations when submitting for execution a batch of circuits."
 
         rotations = kwargs.pop("rotations", [])

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -14,6 +14,9 @@
 """
 This module contains the device class for constructing IonQ devices for PennyLane.
 """
+
+# pylint: disable=too-many-arguments
+
 import inspect
 import logging
 import warnings

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -142,9 +142,7 @@ class IonQDevice(QubitDevice):
         sharpen=False,
     ):
         if shots is None:
-            raise ValueError(
-                "The ionq device does not support analytic expectation values."
-            )
+            raise ValueError("The ionq device does not support analytic expectation values.")
 
         super().__init__(wires=wires, shots=shots)
         self._current_circuit_index = None
@@ -208,8 +206,7 @@ class IonQDevice(QubitDevice):
                 """Entry with args=(circuits=%s) called by=%s""",
                 circuits,
                 "::L".join(
-                    str(i)
-                    for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]
+                    str(i) for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]
                 ),
             )
 
@@ -248,9 +245,7 @@ class IonQDevice(QubitDevice):
 
         if self.tracker.active:
             for circuit in circuits:
-                shots_from_dev = (
-                    self._shots if not self.shot_vector else self._raw_shot_sequence
-                )
+                shots_from_dev = self._shots if not self.shot_vector else self._raw_shot_sequence
                 tape_resources = circuit.specs["resources"]
 
                 resources = Resources(  # temporary until shots get updated on tape !
@@ -279,9 +274,7 @@ class IonQDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         if len(operations) == 0 and len(rotations) == 0:
-            warnings.warn(
-                "Circuit is empty. Empty circuits return failures. Submitting anyway."
-            )
+            warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
 
         for i, operation in enumerate(operations):
             self._apply_operation(operation, circuit_index)
@@ -306,9 +299,7 @@ class IonQDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         if len(operations) == 0 and len(rotations) == 0:
-            warnings.warn(
-                "Circuit is empty. Empty circuits return failures. Submitting anyway."
-            )
+            warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
 
         for i, operation in enumerate(operations):
             self._apply_operation(operation)
@@ -404,9 +395,7 @@ class IonQDevice(QubitDevice):
         # The IonQ API returns basis states using little-endian ordering.
         # Here, we rearrange the states to match the big-endian ordering
         # expected by PennyLane.
-        basis_states = (
-            int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2) for k in histogram
-        )
+        basis_states = (int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2) for k in histogram)
         idx = np.fromiter(basis_states, dtype=int)
 
         # convert the sparse probs into a probability array
@@ -425,9 +414,7 @@ class IonQDevice(QubitDevice):
         if shot_range is None and bin_size is None:
             return self.marginal_prob(self.prob, wires)
 
-        return self.estimate_probability(
-            wires=wires, shot_range=shot_range, bin_size=bin_size
-        )
+        return self.estimate_probability(wires=wires, shot_range=shot_range, bin_size=bin_size)
 
 
 class SimulatorDevice(IonQDevice):


### PR DESCRIPTION
**Context:**
`setuptools` has had a release recently that normalizes package names:

References:
- pypa/setuptools#4766
- https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization

**Description of the Change:**
Due setuptools 75.8.0 and 75.8.1 outputting completely different package names, we cannot support both, so CI now "pins" to >=75.8.1.

**Benefits:**
Fix CI failures.

[sc-85704]