### PR TITLE
Update ubuntu version to 24.04 in readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,7 +25,7 @@ python:
       path: .
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
   apt_packages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  ### Deprecations 👋
 
  ### Internal changes ⚙️
+ - Bumped `.readthedocs.yml` up to Ubuntu-24.04
  
  ### Documentation 📝
  
@@ -18,6 +19,7 @@
  
  This release contains contributions from (in alphabetical order):
  
+ Runor Agbaire
  ---
 # Release 0.41.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
  ### Deprecations 👋
 
  ### Internal changes ⚙️
- - Bumped `.readthedocs.yml` up to Ubuntu-24.04
+
+* The `readthedocs.yml` action has been updated to work with Ubuntu-24.04
+  [(138)](https://github.com/PennyLaneAI/pennylane/pull/138)
  
  ### Documentation 📝
  


### PR DESCRIPTION
**Description of the Change:**
Upgrading the readthedocs.yml runner to Ubuntu-24.04 from Ubuntu22.04; 22.04 is in end of life.

**Benefits:**
The readthedocs runner gets upgrade.

**Possible Drawbacks:**
There could be potential compatibility issues with sphinx and other packages. None were found in the PR run.

**Related GitHub Issues:**
