### PR TITLE
Catch all the `PennyLaneDeprecationWarning` emitted by default shots set up on ionq devices

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -737,8 +737,7 @@ class TestJobAttribute:
 
         result_ionq = dev.batch_execute([tape])
 
-        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
-            simulator = qml.device("default.qubit", wires=2)
+        simulator = qml.device("default.qubit", wires=2)
         result_simulator = qml.execute([tape], simulator)
 
         assert np.allclose(
@@ -758,8 +757,7 @@ class TestJobAttribute:
 
         result_ionq = dev.batch_execute([tape])
 
-        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
-            simulator = qml.device("default.qubit", wires=2)
+        simulator = qml.device("default.qubit", wires=2)
         result_simulator = qml.execute([tape], simulator)
 
         assert np.allclose(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -28,6 +28,7 @@ from pennylane_ionq.device import (
     CircuitIndexNotSetException,
 )
 from pennylane_ionq.ops import GPI, GPI2, MS, XX, YY, ZZ
+from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.measurements import SampleMeasurement, ShotCopies
 from unittest import mock
 
@@ -72,7 +73,11 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("d", shortnames)
     def test_load_device(self, d):
         """Test that the device loads correctly"""
-        dev = qml.device(d, wires=2, shots=1024)
+        with pytest.warns(
+            PennyLaneDeprecationWarning,
+            match = "shots on device is deprecated"
+        ):
+            dev = qml.device(d, wires=2, shots=1024)
         assert dev.num_wires == 2
         assert dev.shots.total_shots == 1024
         assert dev.short_name == d
@@ -183,7 +188,11 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_circuit(self, shots, requires_api, tol):
         """Test that devices provide correct result for a simple circuit"""
-        dev = qml.device("ionq.simulator", wires=1, shots=shots)
+        with pytest.warns(
+            PennyLaneDeprecationWarning,
+            match="shots on device is deprecated"
+        ):
+            dev = qml.device("ionq.simulator", wires=1, shots=shots)
 
         a = 0.543
         b = 0.123
@@ -202,7 +211,11 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_ordering(self, shots, requires_api, tol):
         """Test that probabilities are returned with the correct qubit ordering"""
-        dev = qml.device("ionq.simulator", wires=2, shots=shots)
+        with pytest.warns(
+            PennyLaneDeprecationWarning,
+            match="shots on device is deprecated"
+        ):
+            dev = qml.device("ionq.simulator", wires=2, shots=shots)
 
         @qml.qnode(dev)
         def circuit():
@@ -216,7 +229,11 @@ class TestDeviceIntegration:
     def test_prob_no_results(self, d):
         """Test that the prob attribute is
         None if no job has yet been run."""
-        dev = qml.device(d, wires=1, shots=1)
+        with pytest.warns(
+            PennyLaneDeprecationWarning,
+            match="shots on device is deprecated"
+        ):
+            dev = qml.device(d, wires=1, shots=1)
         assert dev.prob is None
 
     @pytest.mark.parametrize(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -73,10 +73,7 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("d", shortnames)
     def test_load_device(self, d):
         """Test that the device loads correctly"""
-        with pytest.warns(
-            PennyLaneDeprecationWarning,
-            match = "shots on device is deprecated"
-        ):
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
             dev = qml.device(d, wires=2, shots=1024)
         assert dev.num_wires == 2
         assert dev.shots.total_shots == 1024
@@ -85,6 +82,7 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("d", shortnames)
     def test_args(self, d):
         """Test that the device requires correct arguments"""
+
         with pytest.raises(TypeError, match="missing 1 required positional argument"):
             qml.device(d)
 
@@ -133,7 +131,8 @@ class TestDeviceIntegration:
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device("ionq.simulator", wires=1, api_key="test")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=1, api_key="test")
 
         @qml.set_shots(shots)
         @qml.qnode(dev)
@@ -163,12 +162,13 @@ class TestDeviceIntegration:
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device(
-            "ionq.qpu",
-            wires=1,
-            api_key="test",
-            error_mitigation=error_mitigation,
-        )
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device(
+                "ionq.qpu",
+                wires=1,
+                api_key="test",
+                error_mitigation=error_mitigation,
+            )
 
         @qml.set_shots(5000)
         @qml.qnode(dev)
@@ -188,10 +188,7 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_circuit(self, shots, requires_api, tol):
         """Test that devices provide correct result for a simple circuit"""
-        with pytest.warns(
-            PennyLaneDeprecationWarning,
-            match="shots on device is deprecated"
-        ):
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
             dev = qml.device("ionq.simulator", wires=1, shots=shots)
 
         a = 0.543
@@ -211,10 +208,7 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_ordering(self, shots, requires_api, tol):
         """Test that probabilities are returned with the correct qubit ordering"""
-        with pytest.warns(
-            PennyLaneDeprecationWarning,
-            match="shots on device is deprecated"
-        ):
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
             dev = qml.device("ionq.simulator", wires=2, shots=shots)
 
         @qml.qnode(dev)
@@ -229,10 +223,7 @@ class TestDeviceIntegration:
     def test_prob_no_results(self, d):
         """Test that the prob attribute is
         None if no job has yet been run."""
-        with pytest.warns(
-            PennyLaneDeprecationWarning,
-            match="shots on device is deprecated"
-        ):
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
             dev = qml.device(d, wires=1, shots=1)
         assert dev.prob is None
 
@@ -241,11 +232,13 @@ class TestDeviceIntegration:
     )
     def test_backend_initialization(self, backend):
         """Test that the device initializes with the correct backend."""
-        dev = qml.device(
-            "ionq.qpu",
-            wires=2,
-            backend=backend,
-        )
+
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device(
+                "ionq.qpu",
+                wires=2,
+                backend=backend,
+            )
         assert dev.backend == backend
 
     def test_recording_when_pennylane_tracker_active(self, requires_api):
@@ -733,7 +726,9 @@ class TestJobAttribute:
 
     def test_simple_operations_SWAP_gate(self, requires_api):
         """Test SWAP gate operation is correctly processed and sent to IonQ."""
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         with qml.tape.QuantumTape() as tape:
             qml.PauliX(wires=0)
@@ -742,7 +737,8 @@ class TestJobAttribute:
 
         result_ionq = dev.batch_execute([tape])
 
-        simulator = qml.device("default.qubit", wires=2)
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            simulator = qml.device("default.qubit", wires=2)
         result_simulator = qml.execute([tape], simulator)
 
         assert np.allclose(
@@ -751,7 +747,9 @@ class TestJobAttribute:
 
     def test_simple_operations_controlled_gate(self, requires_api):
         """Test a controlled gate operation is correctly processed and sent to IonQ."""
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         with qml.tape.QuantumTape() as tape:
             qml.Hadamard(wires=0)
@@ -760,7 +758,8 @@ class TestJobAttribute:
 
         result_ionq = dev.batch_execute([tape])
 
-        simulator = qml.device("default.qubit", wires=2)
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            simulator = qml.device("default.qubit", wires=2)
         result_simulator = qml.execute([tape], simulator)
 
         assert np.allclose(

--- a/tests/test_pauliexp_ionq_gate.py
+++ b/tests/test_pauliexp_ionq_gate.py
@@ -19,6 +19,7 @@ import pytest
 import re
 
 from scipy.sparse import csr_matrix
+from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.ops.op_math import Prod, SProd, Exp
 
 from pennylane_ionq.exceptions import (
@@ -36,7 +37,8 @@ class TestIonQPauliexp:
         instance Evolution gate is not supported.
         """
 
-        dev = qml.device("ionq.simulator", wires=1, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=1, gateset="qis")
 
         op = qml.S(0)
 
@@ -54,7 +56,8 @@ class TestIonQPauliexp:
         of the Evolution gate is not supported.
         """
 
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         H = qml.sum(qml.H(1), qml.PauliZ(0))
 
@@ -63,9 +66,7 @@ class TestIonQPauliexp:
 
         with pytest.raises(
             OperatorNotSupportedInEvolutionGateGenerator,
-            match=re.escape(
-                "Unsupported operator in generator of Evolution gate: H(1)"
-            ),
+            match=re.escape("Unsupported operator in generator of Evolution gate: H(1)"),
         ):
             dev.batch_execute([tape])
 
@@ -74,7 +75,8 @@ class TestIonQPauliexp:
         an Evolution gate generated via an unsupported operand.
         """
 
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         H = qml.H(0) @ qml.PauliX(1)
 
@@ -91,7 +93,8 @@ class TestIonQPauliexp:
         """Test an exception is thrown when coefficients for Evolution
         gate are complex since IonQ API does not support this."""
 
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         H = SProd(1j, qml.Hamiltonian([1.0], [qml.PauliX(0)]))
 
@@ -107,7 +110,8 @@ class TestIonQPauliexp:
     def test_evolution_gate_print_warning(self, requires_api):
         """A warning is shown to user when using an Evolution gate."""
 
-        dev = qml.device("ionq.simulator", wires=1, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=1, gateset="qis")
 
         H = qml.PauliX(0)
 
@@ -125,7 +129,8 @@ class TestIonQPauliexp:
         works when applied Evolution is generated from an Identity operator.
         """
 
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         H = 3 * qml.Identity(0) @ qml.Identity(1)
 
@@ -166,15 +171,15 @@ class TestIonQPauliexp:
         ],
         ids=lambda val: f"{val}",
     )
-    def test_evolution_object_created_from_hamiltonian(
-        self, wires, coeffs, ops, requires_api
-    ):
+    def test_evolution_object_created_from_hamiltonian(self, wires, coeffs, ops, requires_api):
         """Test that the implementation of Evolution gate derived
         from a Hamiltonian constructed via a Hamiltonian term works.
         """
 
         no_wires = len(wires)
-        dev = qml.device("ionq.simulator", wires=no_wires, gateset="qis")
+
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=no_wires, gateset="qis")
         H = 2 * qml.Hamiltonian(coeffs, ops)
 
         time = 7
@@ -213,14 +218,13 @@ class TestIonQPauliexp:
         ],
         ids=lambda val: f"{val}",
     )
-    def test_evolution_object_created_from_sparse_hamiltonian(
-        self, sparse_matrix, requires_api
-    ):
+    def test_evolution_object_created_from_sparse_hamiltonian(self, sparse_matrix, requires_api):
         """Test that the implementation of Evolution gate derived
         from a Hamiltonian constructed via a sparse Hamiltonian works.
         """
 
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         dense_matrix = sparse_matrix.toarray()
         hermitian_matrix = (dense_matrix + dense_matrix.T.conj()) / 2
@@ -229,9 +233,7 @@ class TestIonQPauliexp:
         H_sparse = qml.SparseHamiltonian(hermitian_sparse, wires=[0, 1])
 
         time = 3
-        tape = qml.tape.QuantumScript(
-            [qml.evolve(H_sparse, time)], [qml.probs(wires=[0, 1])]
-        )
+        tape = qml.tape.QuantumScript([qml.evolve(H_sparse, time)], [qml.probs(wires=[0, 1])])
 
         result_ionq = dev.batch_execute([tape])
 
@@ -242,9 +244,7 @@ class TestIonQPauliexp:
         coeffs, ops = pauli_decomp.terms()
         # qml.TrotterProduct's decomposition reverses the order of the terms
         H = qml.Hamiltonian(coeffs[::-1], ops[::-1])
-        tape = qml.tape.QuantumScript(
-            [qml.TrotterProduct(H, time, n=1)], [qml.probs(wires=[0, 1])]
-        )
+        tape = qml.tape.QuantumScript([qml.TrotterProduct(H, time, n=1)], [qml.probs(wires=[0, 1])])
         simulator = qml.device("default.qubit", wires=2)
         result_simulator = qml.execute([tape], simulator)
 
@@ -265,7 +265,8 @@ class TestIonQPauliexp:
         from a Hamiltonian constructed via an SProd term works.
         """
 
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         time = 3
         tape = qml.tape.QuantumScript([qml.evolve(op, time)], [qml.probs(wires=[0, 1])])
@@ -293,7 +294,8 @@ class TestIonQPauliexp:
         """Test that the implementation of Evolution gate derived
         from an Hamiltonian constructed via prod term works."""
 
-        dev = qml.device("ionq.simulator", wires=len(wires), gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=len(wires), gateset="qis")
 
         H = hamiltonian
 
@@ -315,7 +317,8 @@ class TestIonQPauliexp:
         """Test that the implementation of Evolution gate
         derived from an Hamiltonian constructed via sum works."""
 
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         H = 3 * qml.sum(qml.PauliX(0), qml.PauliZ(1))
 
@@ -336,20 +339,17 @@ class TestIonQPauliexp:
     @pytest.mark.parametrize(
         "H_matrix",
         [
-            np.array(
-                [[1, 1 + 1j, 0, -1j], [1 - 1j, 3, 2, 0], [0, 2, 0, 1j], [1j, 0, -1j, 1]]
-            ),
+            np.array([[1, 1 + 1j, 0, -1j], [1 - 1j, 3, 2, 0], [0, 2, 0, 1j], [1j, 0, -1j, 1]]),
             np.array([[1, 0, 0, 0], [0, 0.5, 0.3, 0], [0, 0.3, 0.5, 0], [0, 0, 0, 1]]),
         ],
         ids=lambda val: f"{val}",
     )
-    def test_evolution_object_created_from_hermitian_matrix(
-        self, H_matrix, requires_api
-    ):
+    def test_evolution_object_created_from_hermitian_matrix(self, H_matrix, requires_api):
         """Test that the implementation of Evolution gate
         derived from a Hamiltonian constructed via a Hermitian matrix."""
 
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         hermitian_op = qml.Hermitian(H_matrix, wires=[0, 1])
 
@@ -367,9 +367,7 @@ class TestIonQPauliexp:
         coeffs, ops = pauli_decomp.terms()
         # qml.TrotterProduct's decomposition reverses the order of the terms
         H = qml.Hamiltonian(coeffs[::-1], ops[::-1])
-        tape = qml.tape.QuantumScript(
-            [qml.TrotterProduct(H, time, n=1)], [qml.probs(wires=[0, 1])]
-        )
+        tape = qml.tape.QuantumScript([qml.TrotterProduct(H, time, n=1)], [qml.probs(wires=[0, 1])])
         simulator = qml.device("default.qubit", wires=2)
         result_simulator = qml.execute([tape], simulator)
 
@@ -381,7 +379,8 @@ class TestIonQPauliexp:
         """Test that the implementation of Evolution gate
         derived from a Hamiltonian constructed via an Exp matrix."""
 
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
+            dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         H = 2.5 * qml.PauliX(0) + 0.5 * qml.PauliY(1)
         t = 3


### PR DESCRIPTION
Due to the fact that we introduced `PennyLaneDeprecationWarning` to legacy facade as well, whenever one calls `qml.device('some_legacy_name',...)`, the same warning shall jump out.