### PR TITLE
Fix silent sign error in Evolution gate & restore Hadamard gradient support

### DIFF
--- a/pennylane_ionq/__init__.py
+++ b/pennylane_ionq/__init__.py
@@ -15,6 +15,7 @@
 PennyLane IonQ overview
 =======================
 """
+
 from .ops import GPI, GPI2, MS, XX, YY, ZZ
 from .device import SimulatorDevice, QPUDevice
 from ._version import __version__

--- a/pennylane_ionq/api_client.py
+++ b/pennylane_ionq/api_client.py
@@ -54,6 +54,7 @@ Exceptions
 
 ----
 """
+
 import urllib
 import json
 import warnings

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -341,7 +341,9 @@ class IonQDevice(QubitDevice):
             # 2. IonQ API expects positive time values for their `pauliexp` gate.
             gate["time"] = abs(float(operation.param))
             # 3. Add missing sign convention to coefficients by multiplying by -1.
-            gate["coefficients"] = [np.sign(operation.param) * (-1) * float(v) for v in coefficients]
+            gate["coefficients"] = [
+                np.sign(operation.param) * (-1) * float(v) for v in coefficients
+            ]
             self.input["circuits"][circuit_index]["circuit"].append(gate)
 
     def _apply_simple_operation(self, operation, circuit_index, wires):

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -339,9 +339,11 @@ class IonQDevice(QubitDevice):
             gate["terms"] = terms
             # 1. Float conversion to prevent numpy types (np.float64) in the JSON payload.
             # 2. IonQ API expects positive time values for their `pauliexp` gate.
+            param_sign = 1 if operation.param >= 0 else -1
             gate["time"] = abs(float(operation.param))
+            gate["coefficients"] = [param_sign * (-1) * float(v) for v in coefficients]
             # 3. Add missing sign convention to coefficients by multiplying by -1.
-            gate["coefficients"] = [-1 * float(v) for v in coefficients]
+            # gate["coefficients"] = [-1 * float(v) for v in coefficients]
             self.input["circuits"][circuit_index]["circuit"].append(gate)
 
     def _apply_simple_operation(self, operation, circuit_index, wires):

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -341,8 +341,7 @@ class IonQDevice(QubitDevice):
             # 2. IonQ API expects positive time values for their `pauliexp` gate.
             gate["time"] = abs(float(operation.param))
             # 3. Add missing sign convention to coefficients by multiplying by -1.
-            param_sign = 1 if operation.param >= 0 else -1
-            gate["coefficients"] = [param_sign * (-1) * float(v) for v in coefficients]
+            gate["coefficients"] = [np.sign(operation.param) * (-1) * float(v) for v in coefficients]
             self.input["circuits"][circuit_index]["circuit"].append(gate)
 
     def _apply_simple_operation(self, operation, circuit_index, wires):

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -339,11 +339,10 @@ class IonQDevice(QubitDevice):
             gate["terms"] = terms
             # 1. Float conversion to prevent numpy types (np.float64) in the JSON payload.
             # 2. IonQ API expects positive time values for their `pauliexp` gate.
-            param_sign = 1 if operation.param >= 0 else -1
             gate["time"] = abs(float(operation.param))
-            gate["coefficients"] = [param_sign * (-1) * float(v) for v in coefficients]
             # 3. Add missing sign convention to coefficients by multiplying by -1.
-            # gate["coefficients"] = [-1 * float(v) for v in coefficients]
+            param_sign = 1 if operation.param >= 0 else -1
+            gate["coefficients"] = [param_sign * (-1) * float(v) for v in coefficients]
             self.input["circuits"][circuit_index]["circuit"].append(gate)
 
     def _apply_simple_operation(self, operation, circuit_index, wires):

--- a/pennylane_ionq/ops.py
+++ b/pennylane_ionq/ops.py
@@ -14,6 +14,7 @@
 """
 Custom operations
 """
+
 import numpy as np
 from pennylane.operation import Operation
 

--- a/tests/test_pauliexp_ionq_gate.py
+++ b/tests/test_pauliexp_ionq_gate.py
@@ -41,7 +41,9 @@ class TestIonQPauliexp:
         op = qml.S(0)
 
         time = 1
-        tape = qml.tape.QuantumScript([qml.evolve(op, time)], [qml.probs(wires=[0])], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(op, time)], [qml.probs(wires=[0])], shots=1024
+        )
 
         with pytest.raises(
             NotSupportedEvolutionInstance,
@@ -59,11 +61,15 @@ class TestIonQPauliexp:
         H = qml.sum(qml.H(1), qml.PauliZ(0))
 
         time = 1
-        tape = qml.tape.QuantumScript([qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024
+        )
 
         with pytest.raises(
             OperatorNotSupportedInEvolutionGateGenerator,
-            match=re.escape("Unsupported operator in generator of Evolution gate: H(1)"),
+            match=re.escape(
+                "Unsupported operator in generator of Evolution gate: H(1)"
+            ),
         ):
             dev.execute([tape])
 
@@ -77,7 +83,9 @@ class TestIonQPauliexp:
         H = qml.H(0) @ qml.PauliX(1)
 
         time = 1
-        tape = qml.tape.QuantumScript([qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024
+        )
 
         with pytest.raises(
             KeyError,
@@ -94,7 +102,9 @@ class TestIonQPauliexp:
         H = SProd(1j, qml.Hamiltonian([1.0], [qml.PauliX(0)]))
 
         time = 1.2
-        tape = qml.tape.QuantumScript([qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024
+        )
 
         with pytest.raises(
             ComplexEvolutionCoefficientsNotSupported,
@@ -110,7 +120,9 @@ class TestIonQPauliexp:
         H = qml.PauliX(0)
 
         time = 1
-        tape = qml.tape.QuantumScript([qml.evolve(H, time)], [qml.probs(wires=[0])], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(H, time)], [qml.probs(wires=[0])], shots=1024
+        )
 
         with pytest.warns(
             UserWarning,
@@ -128,7 +140,9 @@ class TestIonQPauliexp:
         H = 3 * qml.Identity(0) @ qml.Identity(1)
 
         time = 1.5
-        tape = qml.tape.QuantumScript([qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024
+        )
 
         result_ionq = dev.execute([tape])
 
@@ -164,7 +178,9 @@ class TestIonQPauliexp:
         ],
         ids=lambda val: f"{val}",
     )
-    def test_evolution_object_created_from_hamiltonian(self, wires, coeffs, ops, requires_api):
+    def test_evolution_object_created_from_hamiltonian(
+        self, wires, coeffs, ops, requires_api
+    ):
         """Test that the implementation of Evolution gate derived
         from a Hamiltonian constructed via a Hamiltonian term works.
         """
@@ -174,7 +190,9 @@ class TestIonQPauliexp:
         H = 2 * qml.Hamiltonian(coeffs, ops)
 
         time = 7
-        tape = qml.tape.QuantumScript([qml.evolve(H, time)], [qml.probs(wires=wires)], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(H, time)], [qml.probs(wires=wires)], shots=1024
+        )
 
         result_ionq = dev.execute([tape])
 
@@ -209,7 +227,9 @@ class TestIonQPauliexp:
         ],
         ids=lambda val: f"{val}",
     )
-    def test_evolution_object_created_from_sparse_hamiltonian(self, sparse_matrix, requires_api):
+    def test_evolution_object_created_from_sparse_hamiltonian(
+        self, sparse_matrix, requires_api
+    ):
         """Test that the implementation of Evolution gate derived
         from a Hamiltonian constructed via a sparse Hamiltonian works.
         """
@@ -262,7 +282,9 @@ class TestIonQPauliexp:
         dev = qml.device("ionq.simulator", wires=2, gateset="qis")
 
         time = 3
-        tape = qml.tape.QuantumScript([qml.evolve(op, time)], [qml.probs(wires=[0, 1])], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(op, time)], [qml.probs(wires=[0, 1])], shots=1024
+        )
 
         result_ionq = dev.execute([tape])
 
@@ -292,7 +314,9 @@ class TestIonQPauliexp:
         H = hamiltonian
 
         time = 2
-        tape = qml.tape.QuantumScript([qml.evolve(H, time)], [qml.probs(wires=wires)], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(H, time)], [qml.probs(wires=wires)], shots=1024
+        )
 
         result_ionq = dev.execute([tape])
 
@@ -314,7 +338,9 @@ class TestIonQPauliexp:
         H = 3 * qml.sum(qml.PauliX(0), qml.PauliZ(1))
 
         time = 2
-        tape = qml.tape.QuantumScript([qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024
+        )
 
         result_ionq = dev.execute([tape])
 
@@ -330,12 +356,16 @@ class TestIonQPauliexp:
     @pytest.mark.parametrize(
         "H_matrix",
         [
-            np.array([[1, 1 + 1j, 0, -1j], [1 - 1j, 3, 2, 0], [0, 2, 0, 1j], [1j, 0, -1j, 1]]),
+            np.array(
+                [[1, 1 + 1j, 0, -1j], [1 - 1j, 3, 2, 0], [0, 2, 0, 1j], [1j, 0, -1j, 1]]
+            ),
             np.array([[1, 0, 0, 0], [0, 0.5, 0.3, 0], [0, 0.3, 0.5, 0], [0, 0, 0, 1]]),
         ],
         ids=lambda val: f"{val}",
     )
-    def test_evolution_object_created_from_hermitian_matrix(self, H_matrix, requires_api):
+    def test_evolution_object_created_from_hermitian_matrix(
+        self, H_matrix, requires_api
+    ):
         """Test that the implementation of Evolution gate
         derived from a Hamiltonian constructed via a Hermitian matrix."""
 
@@ -346,7 +376,9 @@ class TestIonQPauliexp:
         H = qml.Hamiltonian([2.0], [hermitian_op])
 
         time = 7
-        tape = qml.tape.QuantumScript([qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(H, time)], [qml.probs(wires=[0, 1])], shots=1024
+        )
 
         result_ionq = dev.execute([tape])
 
@@ -357,7 +389,9 @@ class TestIonQPauliexp:
         coeffs, ops = pauli_decomp.terms()
         # qml.TrotterProduct's decomposition reverses the order of the terms
         H = qml.Hamiltonian(coeffs[::-1], ops[::-1])
-        tape = qml.tape.QuantumScript([qml.TrotterProduct(H, time, n=1)], [qml.probs(wires=[0, 1])])
+        tape = qml.tape.QuantumScript(
+            [qml.TrotterProduct(H, time, n=1)], [qml.probs(wires=[0, 1])]
+        )
         simulator = qml.device("default.qubit", wires=2)
         result_simulator = qml.execute([tape.copy(shots=None)], simulator)
 
@@ -376,7 +410,9 @@ class TestIonQPauliexp:
         U = Exp(t * H)
 
         time = 2
-        tape = qml.tape.QuantumScript([qml.evolve(U, time)], [qml.probs(wires=[0, 1])], shots=1024)
+        tape = qml.tape.QuantumScript(
+            [qml.evolve(U, time)], [qml.probs(wires=[0, 1])], shots=1024
+        )
 
         result_ionq = dev.execute([tape])
 
@@ -390,20 +426,26 @@ class TestIonQPauliexp:
         ), "The IonQ and simulator results do not agree."
 
     @pytest.mark.parametrize("time", [0.5, -0.5])
-    def test_evolution_with_negative_time(self, time, requires_api):
-        """Test that Evolution gates with negative time are handled correctly.
+    def test_evolution_sign_correctness(self, time, requires_api):
+        """Test that Evolution gates with negative time produce the correct
+        sign-sensitive results (checking rotation direction).
 
-        This is a regression test for a bug where the sign of negative time
-        was not preserved, causing evolve(H, +t) and evolve(H, -t) to produce
-        identical results.
+        This guards against the bug where abs(time) was applied without
+        sign compensation, which forced all rotations to be positive.
         """
         dev = qml.device("ionq.simulator", wires=1, gateset="qis")
 
         H = qml.PauliZ(0)
 
         tape = qml.tape.QuantumScript(
-            [qml.Hadamard(0), qml.evolve(H, time)],
-            [qml.probs(wires=[0])],
+            [
+                qml.Hadamard(0),  # Prepare |+>
+                qml.evolve(H, time),  # Rotate around Z
+                # We MUST measure PauliY to see the direction of rotation.
+                # PauliX would be cos(t) (insensitive to sign).
+                # Probs would be constant 0.5 (insensitive to sign).
+            ],
+            [qml.expval(qml.PauliY(0))],
             shots=1024,
         )
 


### PR DESCRIPTION
## Description

This PR fixes a critical logic error in the mapping of the `Evolution` gate to IonQ's native `pauliexp` instruction. Previously, negative time parameters were forced to be positive via `abs()` without compensating the Hamiltonian coefficients. This caused backward time evolution ($t < 0$) to erroneously execute as forward time evolution ($t > 0$).

This bug primarily manifested as **silent failures in Hadamard gradient calculations** (gradients $\approx 0$), as this differentiation method relies on time-reversal symmetry which was broken by the plugin. See https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/21419884458/job/61738185102 for example.

### The Bug: "The Lost Sign"
The IonQ API requires the `time` parameter of a `pauliexp` gate to be positive.
* **Previous Behavior:** To satisfy the API, the code applied `abs(operation.param)` to the time argument.
* **The Flaw:** The sign of the parameter was discarded and not propagated into the coefficients.
* **Mathematical Consequence:**
  $$U(-t) = e^{-i(-t)H}$$
  became indistinguishable from
  $$U(t) = e^{-i(t)H}$$
  This effectively destroyed the directionality of time evolution.

### The Fix
The logic in `device.py` has been updated to preserve the unitary equivalence:
$$e^{-i(-t)H} \equiv e^{-i(t)(-H)}$$

1.  **Detect Sign:** Check if the time parameter is negative.
2.  **Compensate:** If negative, multiply all Hamiltonian coefficients by `-1`.
3.  **Sanitize:** Pass `abs(time)` to the hardware to satisfy API constraints.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New test (regression test added)

## Verification
Added a new regression test in `tests/test_evolution_sign_regression.py` that guards against this specific failure mode by checking the negative time as well

1.  Prepare $|+\rangle$.
2.  Evolve under $Z$ by $+t$ and $-t$. Measure PauliY
3.  **Assert:** IonQ and Pennylane results should match for both cases.

*Before this fix, these values were identical. Now they correctly reflect time reversal.*

[sc-109877]