### PR TITLE
fix: update PennyLane's default branch to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 This release contains contributions from (in alphabetical order):
 
+Andrija Paurevic.
+
 ---
 # Release 0.44.0
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,4 +7,4 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 pennylane-sphinx-theme  # do not pin this
-git+https://github.com/PennyLaneAI/pennylane.git@master
+git+https://github.com/PennyLaneAI/pennylane.git@main


### PR DESCRIPTION
PennyLane is moving away from `master` and now has `main` as the default branch.

[sc-113704]