### PR TITLE
[cloned external contribution] Add support for PennyLane's native Ising gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Improvements 🛠
 
+* Support for PennyLane's `IsingXX`, `IsingYY` and `IsingZZ` gates has been added.
+  [(#163)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/163)
+
 ### Breaking changes 💔
 
 ### Deprecations 👋
@@ -16,7 +19,8 @@
 
 This release contains contributions from (in alphabetical order):
 
-Andrija Paurevic.
+Andrija Paurevic,
+David Yonge-Mallo.
 
 ---
 # Release 0.44.0

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -63,10 +63,14 @@ _qis_operation_map = {
     "T.inv": "ti",
     "SX": "v",
     "SX.inv": "vi",
-    # additional operations not native to PennyLane but present in IonQ
+    # Ising gates defined in this plugin for IonQ hardware
     "XX": "xx",
     "YY": "yy",
     "ZZ": "zz",
+    # PennyLane native Ising gates (equivalent to plugin gates above)
+    "IsingXX": "xx",
+    "IsingYY": "yy",
+    "IsingZZ": "zz",
 }
 
 _native_operation_map = {
@@ -352,7 +356,7 @@ class IonQDevice(QubitDevice):
         params = operation.parameters
         gate = {"gate": self._operation_map[name]}
         if len(wires) == 2:
-            if name in {"SWAP", "XX", "YY", "ZZ", "MS"}:
+            if name in {"SWAP", "XX", "YY", "ZZ", "IsingXX", "IsingYY", "IsingZZ", "MS"}:
                 # these gates takes two targets
                 gate["targets"] = wires
             else:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -770,3 +770,30 @@ class TestJobAttribute:
         assert np.allclose(
             result_ionq, result_simulator, atol=1e-5
         ), "The IonQ and simulator results do not agree."
+
+    @pytest.mark.parametrize(
+        "gate_class, expected_ionq_gate",
+        [
+            (qml.IsingXX, "xx"),
+            (qml.IsingYY, "yy"),
+            (qml.IsingZZ, "zz"),
+            (XX, "xx"),
+            (YY, "yy"),
+            (ZZ, "zz"),
+        ],
+    )
+    def test_ising_gate_circuit_generation(self, gate_class, expected_ionq_gate):
+        """Test that Ising gates generate correct circuit structure."""
+        dev = SimulatorDevice(wires=2, shots=1024)
+        dev.reset()
+
+        rotation = 1.23
+        op = gate_class(rotation, wires=[0, 1])
+        dev._apply_operation(op, circuit_index=0)
+
+        gate = dev.input["circuits"][0]["circuit"][0]
+        assert gate["gate"] == expected_ionq_gate
+        assert gate["targets"] == [0, 1]
+        assert "control" not in gate
+        assert "target" not in gate
+        assert gate["rotation"] == rotation


### PR DESCRIPTION
Duplicate of https://github.com/PennyLaneAI/PennyLane-IonQ/pull/163 in order to be able to run integration tests and merge the PR. 

Fixes #40 

[sc-114506]