### PR TITLE
Lift the no warning flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           python setup.py bdist_wheel
           pip install dist/pennylane*.whl
       - name: Run tests
-        run: python -m pytest tests --cov=pennylane_ionq --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
+        run: python -m pytest tests --cov=pennylane_ionq --cov-report=term-missing --cov-report=xml --tb=native
         env:
           IONQ_API_KEY: ${{ secrets.IONQ_API_KEY }}
       - name: Upload coverage to Codecov


### PR DESCRIPTION
`-p no:warnings` suppresses the pytest init filter, so `PennyLaneDeprecationWarning` never becomes an error