### PR TITLE
Add retry logic and configurable timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### New features since last release
 
+* Added configurable timeout, retry logic with exponential backoff, and retriable
+  HTTP status codes for IonQ API requests. Devices now accept `timeout`, `max_retries`,
+  and `retry_delay` keyword arguments.
+  [(#103)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/103)
+
 ### Improvements 🛠
 
 * Support for PennyLane's `IsingXX`, `IsingYY` and `IsingZZ` gates has been added.

--- a/pennylane_ionq/api_client.py
+++ b/pennylane_ionq/api_client.py
@@ -59,10 +59,25 @@ import urllib
 import json
 import warnings
 import os
+import time
 
 import dateutil.parser
 
 import requests
+
+# HTTP status codes that are retriable, based on qiskit-ionq implementation.
+# Includes Cloudflare-specific codes since IonQ uses Cloudflare.
+RETRIABLE_STATUS_CODES = (
+    429,  # Too Many Requests
+    500,  # Internal Server Error
+    502,  # Bad Gateway
+    503,  # Service Unavailable
+    504,  # Gateway Timeout
+    *range(520, 530),  # Cloudflare-specific errors
+)
+
+# 409 Conflict is retriable only for GET requests (Cloudflare DNS resolution errors).
+RETRIABLE_FOR_GET = (409,)
 
 
 def join_path(base_path, path):
@@ -105,17 +120,22 @@ class JobExecutionError(Exception):
     """
 
 
-class APIClient:
+class APIClient:  # pylint: disable=too-many-instance-attributes
     """
     Allows the user to connect to the IonQ Platform API.
 
     Keyword Args:
         api_key (str): IonQ cloud platform API key
+        timeout (float): Request timeout in seconds (default: 600, i.e., 10 minutes).
+            A value of 0 means no timeout.
+        max_retries (int): Maximum number of retries for retriable HTTP errors (default: 3)
+        retry_delay (float): Base delay in seconds between retries (default: 0.5)
     """
 
     USER_AGENT = "pennylane-ionq-api-client/0.4"
     HOSTNAME = "api.ionq.co/v0.4"
     BASE_URL = f"https://{HOSTNAME}"
+    DEFAULT_TIMEOUT = 600
 
     def __init__(self, **kwargs):
         self.AUTHENTICATION_TOKEN = (
@@ -134,8 +154,21 @@ class APIClient:
 
         self.HEADERS = {"User-Agent": self.USER_AGENT}
 
-        # Ten minute timeout on requests.
-        self.TIMEOUT_SECONDS = 60 * 10
+        # Configurable timeout on requests.
+        timeout = kwargs.get("timeout")
+        if timeout is not None and timeout < 0:
+            raise ValueError(f"timeout must be non-negative, got {timeout}")
+        self.TIMEOUT_SECONDS = self.DEFAULT_TIMEOUT if timeout is None else timeout
+
+        # Retry configuration.
+        max_retries = kwargs.get("max_retries")
+        retry_delay = kwargs.get("retry_delay")
+        if max_retries is not None and max_retries < 0:
+            raise ValueError(f"max_retries must be non-negative, got {max_retries}")
+        if retry_delay is not None and retry_delay < 0:
+            raise ValueError(f"retry_delay must be non-negative, got {retry_delay}")
+        self.max_retries = 3 if max_retries is None else max_retries
+        self.retry_delay = 0.5 if retry_delay is None else retry_delay
 
         if self.AUTHENTICATION_TOKEN:
             self.set_authorization_header(self.AUTHENTICATION_TOKEN)
@@ -174,6 +207,10 @@ class APIClient:
         parameters to ``self.errors`` if the request is not successful, and the response to
         ``self.responses`` if a response is returned from the server.
 
+        Implements retry logic with exponential backoff. Status code retries
+        apply only to GET requests (see ``RETRIABLE_STATUS_CODES`` and
+        ``RETRIABLE_FOR_GET``). Connection error retries apply to all methods.
+
         Args:
             method: one of ``requests.get`` or ``requests.post``
             **params: the parameters to pass on to the method (e.g. ``url``, ``data``, etc.)
@@ -187,19 +224,52 @@ class APIClient:
 
         params["headers"] = self.HEADERS
 
-        params["timeout"] = self.TIMEOUT_SECONDS
+        # A timeout of 0 means no timeout; requests expects None for this.
+        params["timeout"] = self.TIMEOUT_SECONDS or None
 
-        try:
-            response = method(**params)
-        except Exception as e:
-            if self.DEBUG:
-                self.errors.append((method, params, e))
-            raise
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = method(**params)
 
-        if self.DEBUG:
-            self.responses.append(response)
+                # Only retry on status codes for GET requests; POST is not
+                # idempotent, so retrying could create duplicate jobs.
+                is_retriable = method == requests.get and (
+                    response.status_code in RETRIABLE_STATUS_CODES + RETRIABLE_FOR_GET
+                )
 
-        return response
+                if is_retriable and attempt < self.max_retries:
+                    # Exponential backoff.
+                    delay = self.retry_delay * (2**attempt)
+                    if self.DEBUG:
+                        self.errors.append(
+                            (
+                                method,
+                                params,
+                                f"Retriable status {response.status_code}, retrying in {delay}s",
+                            )
+                        )
+                    time.sleep(delay)
+                    continue
+
+                if self.DEBUG:
+                    self.responses.append(response)
+
+                return response
+
+            except Exception as e:
+                if self.DEBUG:
+                    self.errors.append((method, params, e))
+
+                # Retry only on requests-related exceptions.
+                if (
+                    isinstance(e, requests.exceptions.RequestException)
+                    and attempt < self.max_retries
+                ):
+                    # Exponential backoff for connection errors.
+                    delay = self.retry_delay * (2**attempt)
+                    time.sleep(delay)
+                    continue
+                raise
 
     def get(self, path, params=None):
         """
@@ -238,15 +308,21 @@ class ResourceManager:
     http_response_status_code = None
     errors = None
 
-    def __init__(self, resource, client=None, api_key=None):
+    def __init__(self, resource, client=None, api_key=None, **kwargs):
         """
         Initialize the manager with resource and client instances. A client
         instance is used as a persistent HTTP communications object, and a
         resource instance corresponds to a particular type of resource (e.g.,
         Job)
+
+        Args:
+            resource: The resource instance to manage.
+            client: An optional APIClient instance.
+            api_key: API key for authentication.
+            **kwargs: Additional arguments passed to APIClient (timeout, max_retries, retry_delay).
         """
         self.resource = resource
-        self.client = client or APIClient(api_key=api_key)
+        self.client = client or APIClient(api_key=api_key, **kwargs)
         self.errors = []
 
     def join_path(self, path):
@@ -302,12 +378,16 @@ class ResourceManager:
             response (requests.Response): a response object to be parsed
         """
         if hasattr(response, "status_code"):
-            self.http_response_data = response.json()
             self.http_response_status_code = response.status_code
 
             if response.status_code in (200, 201):
+                self.http_response_data = response.json()
                 self.handle_success_response(response, params=params)
             else:
+                try:
+                    self.http_response_data = response.json()
+                except (json.JSONDecodeError, ValueError):
+                    self.http_response_data = None
                 self.handle_error_response(response)
         else:
             self.handle_no_response()
@@ -335,7 +415,11 @@ class ResourceManager:
             response (requests.Response): a response object to be parsed
         """
 
-        error = {"status_code": response.status_code, "content": response.json()}
+        try:
+            content = response.json()
+        except (json.JSONDecodeError, ValueError):
+            content = response.text
+        error = {"status_code": response.status_code, "content": content}
         self.errors.append(error)
         try:
             response.raise_for_status()
@@ -373,14 +457,16 @@ class Resource:
     PATH = ""
     fields = ()
 
-    def __init__(self, client=None, api_key=None):
+    def __init__(self, client=None, api_key=None, **kwargs):
         """
         Initialize the Resource by populating attributes based on fields and setting a manager.
 
         Args:
             client (APIClient): An APIClient instance to use as a client.
+            api_key: API key for authentication.
+            **kwargs: Additional arguments passed to APIClient (timeout, max_retries, retry_delay).
         """
-        self.manager = ResourceManager(self, client=client, api_key=api_key)
+        self.manager = ResourceManager(self, client=client, api_key=api_key, **kwargs)
         for field in self.fields:
             setattr(self, field.name, field)
 
@@ -453,9 +539,14 @@ class Job(Resource):
     SUPPORTED_METHODS = ("GET", "POST")
     PATH = "jobs"
 
-    def __init__(self, client=None, api_key=None):
+    def __init__(self, client=None, api_key=None, **kwargs):
         """
         Initialize the Job resource with a set of pre-defined fields.
+
+        Args:
+            client (APIClient): An APIClient instance to use as a client.
+            api_key: API key for authentication.
+            **kwargs: Additional arguments passed to APIClient (timeout, max_retries, retry_delay).
         """
         self.fields = (
             Field("id", str),
@@ -470,7 +561,7 @@ class Job(Resource):
         self.result = None
         self.circuit = None
 
-        super().__init__(client=client, api_key=api_key)
+        super().__init__(client=client, api_key=api_key, **kwargs)
 
     @property
     def is_complete(self):

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -126,6 +126,12 @@ class IonQDevice(QubitDevice):
         dry_run (bool): If True, the job will be submitted by the API client but not processed remotely.
             Useful for obtaining cost estimates. Defaults to False.
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
+        timeout (float): Request timeout in seconds. Defaults to None, which uses the
+            ``APIClient`` default.
+        max_retries (int): Maximum number of retries for retriable HTTP errors. Defaults to
+            None, which uses the ``APIClient`` default.
+        retry_delay (float): Base delay in seconds between retries (uses exponential backoff).
+            Defaults to None, which uses the ``APIClient`` default.
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -161,6 +167,9 @@ class IonQDevice(QubitDevice):
         dry_run=False,
         noise=None,
         metadata=None,
+        timeout=None,
+        max_retries=None,
+        retry_delay=None,
     ):
 
         super().__init__(wires=wires, shots=shots)
@@ -178,6 +187,12 @@ class IonQDevice(QubitDevice):
         self._operation_map = _GATESET_OPS[gateset]
         self.histograms = []
         self._samples = None
+
+        # API client configuration.
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+
         self.reset()
 
     def batch_transform(self, circuit):
@@ -549,8 +564,12 @@ class IonQDevice(QubitDevice):
         return ionq_terms
 
     def _submit_job(self):
-
-        job = Job(api_key=self.api_key)
+        job = Job(
+            api_key=self.api_key,
+            timeout=self.timeout,
+            max_retries=self.max_retries,
+            retry_delay=self.retry_delay,
+        )
 
         # send job for execution
         job.manager.create(**self.job)
@@ -644,6 +663,12 @@ class SimulatorDevice(IonQDevice):
             variable ``IONQ_API_KEY`` is used.
         noise (dict | None): {"model": str, "seed": int or None}. Defaults to None.
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
+        timeout (float): Request timeout in seconds. Defaults to None, which uses the
+            ``APIClient`` default.
+        max_retries (int): Maximum number of retries for retriable HTTP errors. Defaults to
+            None, which uses the ``APIClient`` default.
+        retry_delay (float): Base delay in seconds between retries (uses exponential backoff).
+            Defaults to None, which uses the ``APIClient`` default.
     """
 
     name = "IonQ Simulator PennyLane plugin"
@@ -661,6 +686,9 @@ class SimulatorDevice(IonQDevice):
         dry_run=False,
         noise=None,
         metadata=None,
+        timeout=None,
+        max_retries=None,
+        retry_delay=None,
     ):
         super().__init__(
             wires=wires,
@@ -673,6 +701,9 @@ class SimulatorDevice(IonQDevice):
             dry_run=dry_run,
             noise=noise,
             metadata=metadata,
+            timeout=timeout,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
         )
 
     def generate_samples(self):
@@ -714,6 +745,12 @@ class QPUDevice(IonQDevice):
             <https://ionq.com/resources/debiasing-and-sharpening>`_ for details.
         dry_run (bool): whether to run the job in dry run mode. Defaults to False.
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
+        timeout (float): Request timeout in seconds. Defaults to None, which uses the
+            ``APIClient`` default.
+        max_retries (int): Maximum number of retries for retriable HTTP errors. Defaults to
+            None, which uses the ``APIClient`` default.
+        retry_delay (float): Base delay in seconds between retries (uses exponential backoff).
+            Defaults to None, which uses the ``APIClient`` default.
     """
 
     name = "IonQ QPU PennyLane plugin"
@@ -734,6 +771,9 @@ class QPUDevice(IonQDevice):
         api_key=None,
         dry_run=False,
         metadata=None,
+        timeout=None,
+        max_retries=None,
+        retry_delay=None,
     ):
         target = "qpu"
         self.backend = backend
@@ -751,6 +791,9 @@ class QPUDevice(IonQDevice):
             sharpen=sharpen,
             dry_run=dry_run,
             metadata=metadata,
+            timeout=timeout,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
         )
 
     def generate_samples(self):

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -271,6 +271,30 @@ class TestResourceManager:
         manager.handle_response(mock_response)
         mock_handle_success_response.assert_called_once_with(mock_response, params=None)
 
+    def test_handle_response_non_json_error(self):
+        """
+        Tests that a non-JSON error response (e.g. Cloudflare HTML) does not raise
+        JSONDecodeError and is handled gracefully.
+        """
+        mock_resource = MagicMock()
+        mock_client = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_response.json.side_effect = json.JSONDecodeError("msg", "doc", 0)
+        mock_response.text = "<html>503 Service Unavailable</html>"
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError()
+
+        manager = ResourceManager(mock_resource, mock_client)
+
+        with pytest.raises(Exception, match="503 Service Unavailable"):
+            manager.handle_response(mock_response)
+
+        assert manager.http_response_data is None
+        assert manager.http_response_status_code == 503
+        assert manager.errors[0]["status_code"] == 503
+        assert manager.errors[0]["content"] == "<html>503 Service Unavailable</html>"
+
     def test_handle_refresh_data(self):
         """
         Tests the ResourceManager.refresh_data method.

--- a/tests/test_api_client_retry.py
+++ b/tests/test_api_client_retry.py
@@ -1,0 +1,242 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for HTTP retry logic in APIClient"""
+from unittest.mock import Mock, patch
+import os
+
+import pytest
+import requests
+
+from pennylane_ionq.api_client import APIClient
+
+
+class TestAPIClientRetryConfig:
+    """Test retry configuration in APIClient."""
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    def test_default_retry_config(self):
+        """Test default retry configuration."""
+        client = APIClient()
+        assert client.max_retries == 3
+        assert client.retry_delay == 0.5
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    def test_custom_retry_config(self):
+        """Test custom retry configuration."""
+        client = APIClient(max_retries=5, retry_delay=1.0)
+        assert client.max_retries == 5
+        assert client.retry_delay == 1.0
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    def test_negative_max_retries_rejected(self):
+        """Test that negative max_retries raises ValueError."""
+        with pytest.raises(ValueError, match="max_retries must be non-negative"):
+            APIClient(max_retries=-1)
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    def test_negative_retry_delay_rejected(self):
+        """Test that negative retry_delay raises ValueError."""
+        with pytest.raises(ValueError, match="retry_delay must be non-negative"):
+            APIClient(retry_delay=-1.0)
+
+
+class TestRetryLogic:
+    """Test retry behaviour in request method."""
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.get")
+    @patch("pennylane_ionq.api_client.time.sleep")
+    def test_retry_on_retriable_status(self, mock_sleep, mock_get):
+        """Test that retriable status codes are retried."""
+        mock_response_503 = Mock()
+        mock_response_503.status_code = 503
+
+        mock_response_200 = Mock()
+        mock_response_200.status_code = 200
+
+        mock_get.side_effect = [mock_response_503, mock_response_503, mock_response_200]
+
+        client = APIClient(max_retries=3, retry_delay=0.1)
+        response = client.get("test/path")
+
+        assert response.status_code == 200
+        assert mock_get.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.get")
+    @patch("pennylane_ionq.api_client.time.sleep")
+    def test_retry_409_on_get(self, mock_sleep, mock_get):
+        """Test that 409 is retried on GET requests."""
+        mock_response_409 = Mock()
+        mock_response_409.status_code = 409
+
+        mock_response_200 = Mock()
+        mock_response_200.status_code = 200
+
+        mock_get.side_effect = [mock_response_409, mock_response_200]
+
+        client = APIClient(max_retries=3, retry_delay=0.1)
+        response = client.get("test/path")
+
+        assert response.status_code == 200
+        assert mock_get.call_count == 2
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.post")
+    @patch("pennylane_ionq.api_client.time.sleep")
+    def test_no_retry_409_on_post(self, mock_sleep, mock_post):
+        """Test that 409 is NOT retried on POST requests."""
+        mock_response_409 = Mock()
+        mock_response_409.status_code = 409
+
+        mock_post.return_value = mock_response_409
+
+        client = APIClient(max_retries=3, retry_delay=0.1)
+        response = client.post("test/path", {"data": "value"})
+
+        assert response.status_code == 409
+        assert mock_post.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.post")
+    @patch("pennylane_ionq.api_client.time.sleep")
+    def test_no_retry_503_on_post(self, mock_sleep, mock_post):
+        """Test that 503 is NOT retried on POST requests (non-idempotent)."""
+        mock_response_503 = Mock()
+        mock_response_503.status_code = 503
+
+        mock_post.return_value = mock_response_503
+
+        client = APIClient(max_retries=3, retry_delay=0.1)
+        response = client.post("test/path", {"data": "value"})
+
+        assert response.status_code == 503
+        assert mock_post.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.get")
+    @patch("pennylane_ionq.api_client.time.sleep")
+    def test_no_retry_on_400(self, mock_sleep, mock_get):
+        """Test that non-retriable client errors are not retried."""
+        mock_response_400 = Mock()
+        mock_response_400.status_code = 400
+
+        mock_get.return_value = mock_response_400
+
+        client = APIClient(max_retries=3, retry_delay=0.1)
+        response = client.get("test/path")
+
+        assert response.status_code == 400
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.get")
+    @patch("pennylane_ionq.api_client.time.sleep")
+    def test_retry_on_500(self, mock_sleep, mock_get):
+        """Test that 500 Internal Server Error is retried."""
+        mock_response_500 = Mock()
+        mock_response_500.status_code = 500
+
+        mock_response_200 = Mock()
+        mock_response_200.status_code = 200
+
+        mock_get.side_effect = [mock_response_500, mock_response_200]
+
+        client = APIClient(max_retries=3, retry_delay=0.1)
+        response = client.get("test/path")
+
+        assert response.status_code == 200
+        assert mock_get.call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.get")
+    @patch("pennylane_ionq.api_client.time.sleep")
+    def test_exponential_backoff(self, mock_sleep, mock_get):
+        """Test that exponential backoff is applied between retries."""
+        mock_response_503 = Mock()
+        mock_response_503.status_code = 503
+
+        mock_response_200 = Mock()
+        mock_response_200.status_code = 200
+
+        mock_get.side_effect = [mock_response_503, mock_response_503, mock_response_503, mock_response_200]
+
+        client = APIClient(max_retries=3, retry_delay=1.0)
+        response = client.get("test/path")
+
+        calls = mock_sleep.call_args_list
+        assert len(calls) == 3
+        assert calls[0][0][0] == 1.0   # delay * 2^0
+        assert calls[1][0][0] == 2.0   # delay * 2^1
+        assert calls[2][0][0] == 4.0   # delay * 2^2
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.get")
+    @patch("pennylane_ionq.api_client.time.sleep")
+    def test_exhausted_retries_returns_last_response(self, mock_sleep, mock_get):
+        """Test that exhausted retries return the last response."""
+        mock_response_503 = Mock()
+        mock_response_503.status_code = 503
+
+        mock_get.return_value = mock_response_503
+
+        client = APIClient(max_retries=2, retry_delay=0.1)
+        response = client.get("test/path")
+
+        assert response.status_code == 503
+        assert mock_get.call_count == 3  # initial + 2 retries
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.get")
+    @patch("pennylane_ionq.api_client.time.sleep")
+    def test_retry_on_connection_error(self, mock_sleep, mock_get):
+        """Test that connection errors are retried."""
+        mock_response_200 = Mock()
+        mock_response_200.status_code = 200
+
+        mock_get.side_effect = [
+            requests.exceptions.ConnectionError("Connection failed"),
+            mock_response_200,
+        ]
+
+        client = APIClient(max_retries=3, retry_delay=0.1)
+        response = client.get("test/path")
+
+        assert response.status_code == 200
+        assert mock_get.call_count == 2
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.get")
+    @patch("pennylane_ionq.api_client.time.sleep")
+    def test_retry_logs_errors_in_debug_mode(self, mock_sleep, mock_get):
+        """Test that retriable status codes are logged to errors when debug mode is enabled."""
+        mock_response_503 = Mock()
+        mock_response_503.status_code = 503
+
+        mock_response_200 = Mock()
+        mock_response_200.status_code = 200
+
+        mock_get.side_effect = [mock_response_503, mock_response_200]
+
+        client = APIClient(debug=True, max_retries=3, retry_delay=0.1)
+        response = client.get("test/path")
+
+        assert response.status_code == 200
+        assert len(client.errors) == 1
+        assert "Retriable status 503" in client.errors[0][2]

--- a/tests/test_api_client_timeout.py
+++ b/tests/test_api_client_timeout.py
@@ -1,0 +1,102 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for configurable timeout in APIClient"""
+from unittest.mock import Mock, patch
+import os
+
+import pytest
+
+from pennylane_ionq.api_client import APIClient, Job
+
+
+class TestTimeoutConfig:
+    """Test timeout configuration in APIClient."""
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    def test_default_timeout(self):
+        """Test default timeout is 600 seconds (10 minutes)."""
+        client = APIClient()
+        assert client.TIMEOUT_SECONDS == 600
+        assert client.DEFAULT_TIMEOUT == 600
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    def test_custom_timeout(self):
+        """Test custom timeout can be set."""
+        client = APIClient(timeout=1800)
+        assert client.TIMEOUT_SECONDS == 1800
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    def test_none_timeout_uses_default(self):
+        """Test that passing None uses the default timeout."""
+        client = APIClient(timeout=None)
+        assert client.TIMEOUT_SECONDS == 600
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.get")
+    def test_zero_timeout(self, mock_get):
+        """Test that timeout=0 means no timeout (passed as None to requests)."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        client = APIClient(timeout=0)
+        assert client.TIMEOUT_SECONDS == 0
+
+        client.get("test/path")
+        call_kwargs = mock_get.call_args[1]
+        assert call_kwargs["timeout"] is None
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    def test_negative_timeout_rejected(self):
+        """Test that a negative timeout raises ValueError."""
+        with pytest.raises(ValueError, match="timeout must be non-negative"):
+            APIClient(timeout=-1)
+
+
+class TestTimeoutApplied:
+    """Test that timeout is applied to requests."""
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    @patch("pennylane_ionq.api_client.requests.get")
+    def test_timeout_passed_to_requests(self, mock_get):
+        """Test that the configured timeout is passed to the HTTP call."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        client = APIClient(timeout=120)
+        client.get("test/path")
+
+        call_kwargs = mock_get.call_args[1]
+        assert call_kwargs["timeout"] == 120
+
+
+class TestJobPropagation:
+    """Test that config is propagated through Job/ResourceManager."""
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    def test_job_passes_config_to_client(self):
+        """Test that Job passes timeout and retry config to APIClient."""
+        job = Job(timeout=1200, max_retries=5, retry_delay=2.0)
+        assert job.manager.client.TIMEOUT_SECONDS == 1200
+        assert job.manager.client.max_retries == 5
+        assert job.manager.client.retry_delay == 2.0
+
+    @patch.dict(os.environ, {"IONQ_API_KEY": "test_key"})
+    def test_job_default_config(self):
+        """Test that Job uses default config when none provided."""
+        job = Job()
+        assert job.manager.client.TIMEOUT_SECONDS == 600
+        assert job.manager.client.max_retries == 3
+        assert job.manager.client.retry_delay == 0.5

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -35,6 +35,19 @@ from unittest import mock
 FAKE_API_KEY = "ABC123"
 
 
+class MockPOSTResponse:
+    """Mock POST response for tests that need a response object with status_code."""
+
+    def __init__(self, status_code=201, url=None, data=None, headers=None):
+        self.status_code = status_code
+        self.url = url
+        self.data = data
+        self.headers = headers
+
+    def json(self):
+        return {}
+
+
 class TestDevice:
     """Tests for the IonQDevice class."""
 
@@ -111,7 +124,8 @@ class TestDeviceIntegration:
 
     def test_failedcircuit(self, monkeypatch):
         monkeypatch.setattr(
-            requests, "post", lambda url, timeout, data, headers: (url, data, headers)
+            requests, "post",
+            lambda url, timeout, data, headers: MockPOSTResponse(201, url, data, headers)
         )
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", False)
@@ -126,7 +140,8 @@ class TestDeviceIntegration:
         """Test that shots are correctly specified when submitting a job to the API."""
 
         monkeypatch.setattr(
-            requests, "post", lambda url, timeout, data, headers: (url, data, headers)
+            requests, "post",
+            lambda url, timeout, data, headers: MockPOSTResponse(201, url, data, headers)
         )
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
@@ -335,7 +350,8 @@ class TestDeviceIntegration:
         """Test that error mitigation settings are properly handled when submitting a job to the API."""
 
         monkeypatch.setattr(
-            requests, "post", lambda url, timeout, data, headers: (url, data, headers)
+            requests, "post",
+            lambda url, timeout, data, headers: MockPOSTResponse(201, url, data, headers)
         )
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -1,0 +1,88 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for device configuration (timeout, retry settings)"""
+from unittest.mock import Mock, patch
+
+from pennylane_ionq.device import IonQDevice
+
+
+FAKE_API_KEY = "ABC123"
+
+
+class TestDeviceConfigInit:
+    """Test that IonQDevice accepts configuration parameters."""
+
+    def test_accepts_timeout(self):
+        """Test that IonQDevice accepts timeout parameter."""
+        dev = IonQDevice(wires=2, shots=100, api_key=FAKE_API_KEY, timeout=1800)
+        assert dev.timeout == 1800
+
+    def test_accepts_retry_config(self):
+        """Test that IonQDevice accepts retry configuration."""
+        dev = IonQDevice(
+            wires=2, shots=100, api_key=FAKE_API_KEY,
+            max_retries=5, retry_delay=2.0
+        )
+        assert dev.max_retries == 5
+        assert dev.retry_delay == 2.0
+
+    def test_default_config_is_none(self):
+        """Test that IonQDevice has None defaults for optional config."""
+        dev = IonQDevice(wires=2, shots=100, api_key=FAKE_API_KEY)
+        assert dev.timeout is None
+        assert dev.max_retries is None
+        assert dev.retry_delay is None
+
+
+class TestDeviceConfigPropagation:
+    """Test that config is propagated to Job during job submission."""
+
+    @patch("pennylane_ionq.device.Job")
+    def test_submit_job_passes_config(self, mock_job_class):
+        """Test that _submit_job passes all config to Job."""
+        mock_job = Mock()
+        mock_job.is_complete = True
+        mock_job.is_failed = False
+        mock_job.id.value = "test-id"
+        mock_job.data.value = {"0": 1.0}
+        mock_job_class.return_value = mock_job
+
+        dev = IonQDevice(
+            wires=2, shots=100, api_key=FAKE_API_KEY,
+            timeout=1800, max_retries=5, retry_delay=2.0
+        )
+        dev._submit_job()
+
+        call_kwargs = mock_job_class.call_args[1]
+        assert call_kwargs["timeout"] == 1800
+        assert call_kwargs["max_retries"] == 5
+        assert call_kwargs["retry_delay"] == 2.0
+
+    @patch("pennylane_ionq.device.Job")
+    def test_submit_job_none_config_uses_defaults(self, mock_job_class):
+        """Test that None config values are passed through to APIClient."""
+        mock_job = Mock()
+        mock_job.is_complete = True
+        mock_job.is_failed = False
+        mock_job.id.value = "test-id"
+        mock_job.data.value = {"0": 1.0}
+        mock_job_class.return_value = mock_job
+
+        dev = IonQDevice(wires=2, shots=100, api_key=FAKE_API_KEY)
+        dev._submit_job()
+
+        call_kwargs = mock_job_class.call_args[1]
+        assert call_kwargs["timeout"] is None
+        assert call_kwargs["max_retries"] is None
+        assert call_kwargs["retry_delay"] is None


### PR DESCRIPTION
Fixes #56, #103.

Retry transient HTTP errors (429, 502-504, Cloudflare 520-529) with exponential backoff. Make `timeout`, `max_retries`, and `retry_delay` configurable through the device interface.
