### PR TITLE
fix: add clarifaction about non-physical wire labels

### DIFF
--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -101,6 +101,7 @@ class IonQDevice(QubitDevice):
 
                 Custom wire labels (e.g., strings or non-consecutive integers) are used for user convenience only.
                 They have no effect on the transpilation process or the final qubit layout on the hardware.
+
     Kwargs:
         target (str): the target device, either ``"simulator"`` or ``"qpu"``. Defaults to ``simulator``.
         gateset (str): the target gateset, either ``"qis"`` or ``"native"``. Defaults to ``qis``.

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -591,6 +591,12 @@ class SimulatorDevice(IonQDevice):
         wires (int or Iterable[Number, str]]): Number of wires to initialize the device with,
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['ancilla', 'q1', 'q2']``).
+
+            .. note::
+
+                Custom wire labels (e.g., strings or non-consecutive integers) are used for user convenience only.
+                They have no effect on the transpilation process or the final qubit layout on the hardware.
+
         gateset (str): the target gateset, either ``"qis"`` or ``"native"``. Defaults to ``qis``.
         shots (int, list[int], None): Number of circuit evaluations/random samples used to estimate
             expectation values of observables. If ``None``, the device calculates probability, expectation values,
@@ -627,6 +633,12 @@ class QPUDevice(IonQDevice):
         wires (int or Iterable[Number, str]]): Number of wires to initialize the device with,
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['ancilla', 'q1', 'q2']``).
+
+            .. note::
+
+                Custom wire labels (e.g., strings or non-consecutive integers) are used for user convenience only.
+                They have no effect on the transpilation process or the final qubit layout on the hardware.
+
         gateset (str): the target gateset, either ``"qis"`` or ``"native"``. Defaults to ``qis``.
         backend (str): Optional specifier for an IonQ backend. Can be ``"aria-1"``, ``"aria-2"``, etc.
             Default to ``aria-1``.

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -97,6 +97,10 @@ class IonQDevice(QubitDevice):
             or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
             or strings (``['ancilla', 'q1', 'q2']``).
 
+            .. note::
+
+                Custom wire labels (e.g., strings or non-consecutive integers) are used for user convenience only.
+                They have no effect on the transpilation process or the final qubit layout on the hardware.
     Kwargs:
         target (str): the target device, either ``"simulator"`` or ``"qpu"``. Defaults to ``simulator``.
         gateset (str): the target gateset, either ``"qis"`` or ``"native"``. Defaults to ``qis``.


### PR DESCRIPTION
We're making it clearer to users that non-physical wire labels are purely for convenience and don't inform any hardware transpilation.

[sc-113246]