### PR TITLE
Add simulator noise model support

### DIFF
--- a/doc/devices.rst
+++ b/doc/devices.rst
@@ -10,10 +10,10 @@ trapped-ion simulator and another to access to IonQ's trapped-ion QPUs.
 .. raw::html
     <section id="simulator">
 
-Ideal trapped-ion simulator
+Trapped-ion simulator
 ------------------------
 
-The :class:`~.pennylane_ionq.SimulatorDevice` provides an ideal noiseless trapped-ion simulation.
+The :class:`~.pennylane_ionq.SimulatorDevice` provides a trapped-ion simulation.
 Once the plugin has been installed, you can use this device directly in PennyLane by specifying ``"ionq.simulator"``:
 
 .. code-block:: python
@@ -29,6 +29,27 @@ Once the plugin has been installed, you can use this device directly in PennyLan
         ops.YY(y, wires=[0,1])
         ops.ZZ(z, wires=[0,1])
         return qml.expval(qml.PauliZ(0))
+
+Hardware noise model simulation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The simulator supports hardware-aware noise models that approximate the noise characteristics
+of IonQ's trapped-ion QPUs. To enable a noise model, pass the ``noise_model`` parameter:
+
+.. code-block:: python
+
+    dev = qml.device("ionq.simulator", wires=2, noise_model="aria-1")
+
+Available noise models are ``"ideal"`` (default, noiseless), ``"harmony"``, ``"aria-1"``,
+``"aria-2"``, ``"forte-1"``, and ``"forte-enterprise-1"``. For reproducible results, you can
+also set a ``noise_seed``:
+
+.. code-block:: python
+
+    dev = qml.device("ionq.simulator", wires=2, noise_model="aria-1", noise_seed=42)
+
+See the `IonQ noise model documentation <https://docs.ionq.com/guides/simulation-with-noise-models>`_
+for details on each noise model.
 
 .. raw::html
     </section>

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -128,7 +128,7 @@ class IonQDevice(QubitDevice):
             `IonQ Simulation with Noise Models <https://docs.ionq.com/guides/simulation-with-noise-models>`_
             for details.
         noise_seed (int): seed for the noise model random number generator, for reproducible noisy
-            simulation results. Must be an integer between 1 and 2^31 - 1. Only used when ``noise_model`` is set.
+            simulation results. Must be an integer between 1 and 2\ :sup:`31` - 1. Only used when ``noise_model`` is set.
             Defaults to None (random seed).
         dry_run (bool): If True, the job will be submitted by the API client but not processed remotely.
             Useful for obtaining cost estimates. Defaults to False.
@@ -686,7 +686,7 @@ class SimulatorDevice(IonQDevice):
             `IonQ Simulation with Noise Models <https://docs.ionq.com/guides/simulation-with-noise-models>`_
             for details.
         noise_seed (int): seed for the noise model random number generator, for reproducible noisy
-            simulation results. Must be an integer between 1 and 2^31 - 1. Only used when ``noise_model`` is set.
+            simulation results. Must be an integer between 1 and 2\ :sup:`31` - 1. Only used when ``noise_model`` is set.
             Defaults to None (random seed).
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
     """

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -128,7 +128,7 @@ class IonQDevice(QubitDevice):
             `IonQ Simulation with Noise Models <https://docs.ionq.com/guides/simulation-with-noise-models>`_
             for details.
         noise_seed (int): seed for the noise model random number generator, for reproducible noisy
-            simulation results. Must be between 1 and 2^31. Only used when ``noise_model`` is set.
+            simulation results. Must be an integer between 1 and 2^31 - 1. Only used when ``noise_model`` is set.
             Defaults to None (random seed).
         dry_run (bool): If True, the job will be submitted by the API client but not processed remotely.
             Useful for obtaining cost estimates. Defaults to False.
@@ -185,10 +185,16 @@ class IonQDevice(QubitDevice):
                 f"Invalid noise model '{noise_model}'. Valid options are: "
                 f"{', '.join(sorted(self.NOISE_MODELS))}."
             )
+        if noise_seed is not None and noise_model is None:
+            raise ValueError("noise_seed requires noise_model to be set.")
         if noise_seed is not None:
-            if not isinstance(noise_seed, int) or noise_seed < 1 or noise_seed > 2**31:
+            if (
+                isinstance(noise_seed, bool)
+                or not isinstance(noise_seed, int)
+                or not 1 <= noise_seed <= 2**31 - 1
+            ):
                 raise ValueError(
-                    f"noise_seed must be an integer between 1 and 2^31, got {noise_seed}."
+                    f"noise_seed must be an integer between 1 and 2^31 - 1, got {noise_seed}."
                 )
 
         super().__init__(wires=wires, shots=shots)
@@ -680,7 +686,7 @@ class SimulatorDevice(IonQDevice):
             `IonQ Simulation with Noise Models <https://docs.ionq.com/guides/simulation-with-noise-models>`_
             for details.
         noise_seed (int): seed for the noise model random number generator, for reproducible noisy
-            simulation results. Must be between 1 and 2^31. Only used when ``noise_model`` is set.
+            simulation results. Must be an integer between 1 and 2^31 - 1. Only used when ``noise_model`` is set.
             Defaults to None (random seed).
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
     """

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -122,7 +122,14 @@ class IonQDevice(QubitDevice):
             (no value passed at job retrieval). Will generally return more accurate results if your expected output
             distribution has peaks. See `IonQ Debiasing and Sharpening
             <https://ionq.com/resources/debiasing-and-sharpening>`_ for details.
-        noise (dict | None): {"model": str, "seed": int or None}. Defaults to None.
+        noise_model (str): the noise model to use for simulation. Only applies when ``target="simulator"``.
+            Valid values are ``"ideal"``, ``"harmony"``, ``"aria-1"``, ``"aria-2"``, ``"forte-1"``,
+            and ``"forte-enterprise-1"``. Defaults to None (ideal simulation). See
+            `IonQ Simulation with Noise Models <https://docs.ionq.com/guides/simulation-with-noise-models>`_
+            for details.
+        noise_seed (int): seed for the noise model random number generator, for reproducible noisy
+            simulation results. Must be between 1 and 2^31. Only used when ``noise_model`` is set.
+            Defaults to None (random seed).
         dry_run (bool): If True, the job will be submitted by the API client but not processed remotely.
             Useful for obtaining cost estimates. Defaults to False.
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
@@ -146,6 +153,15 @@ class IonQDevice(QubitDevice):
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Identity", "Prod"}
 
     # pylint: disable=too-many-arguments
+    NOISE_MODELS = {
+        "ideal",
+        "harmony",
+        "aria-1",
+        "aria-2",
+        "forte-1",
+        "forte-enterprise-1",
+    }
+
     def __init__(
         self,
         wires,
@@ -158,10 +174,22 @@ class IonQDevice(QubitDevice):
         compilation=None,
         error_mitigation=None,
         sharpen=None,
+        noise_model=None,
+        noise_seed=None,
         dry_run=False,
-        noise=None,
         metadata=None,
     ):
+
+        if noise_model is not None and noise_model not in self.NOISE_MODELS:
+            raise ValueError(
+                f"Invalid noise model '{noise_model}'. Valid options are: "
+                f"{', '.join(sorted(self.NOISE_MODELS))}."
+            )
+        if noise_seed is not None:
+            if not isinstance(noise_seed, int) or noise_seed < 1 or noise_seed > 2**31:
+                raise ValueError(
+                    f"noise_seed must be an integer between 1 and 2^31, got {noise_seed}."
+                )
 
         super().__init__(wires=wires, shots=shots)
         self._current_circuit_index = None
@@ -172,8 +200,9 @@ class IonQDevice(QubitDevice):
         self.compilation = compilation
         self.error_mitigation = error_mitigation
         self.sharpen = sharpen
+        self.noise_model = noise_model
+        self.noise_seed = noise_seed
         self.dry_run = dry_run
-        self.noise = noise
         self.metadata = metadata
         self._operation_map = _GATESET_OPS[gateset]
         self.histograms = []
@@ -197,11 +226,17 @@ class IonQDevice(QubitDevice):
             "gateset": self.gateset,
         }
         if circuits_array_length > 1:
-            self.input["circuits"] = [{"circuit": []} for _ in range(circuits_array_length)]
+            self.input["circuits"] = [
+                {"circuit": []} for _ in range(circuits_array_length)
+            ]
         else:
             self.input["circuit"] = []
         self.job = {
-            "type": ("ionq.multi-circuit.v1" if circuits_array_length > 1 else "ionq.circuit.v1"),
+            "type": (
+                "ionq.multi-circuit.v1"
+                if circuits_array_length > 1
+                else "ionq.circuit.v1"
+            ),
             "input": self.input,
             "backend": self.target,
         }
@@ -211,8 +246,11 @@ class IonQDevice(QubitDevice):
             self.job["name"] = self.job_name
         if self.dry_run:
             self.job["dry_run"] = self.dry_run
-        if self.noise is not None:
-            self.job["noise"] = self.noise
+        if self.noise_model is not None:
+            noise = {"model": self.noise_model}
+            if self.noise_seed is not None:
+                noise["seed"] = self.noise_seed
+            self.job["noise"] = noise
         if self.metadata is not None:
             self.job["metadata"] = self.metadata
         if self.compilation is not None:
@@ -253,7 +291,8 @@ class IonQDevice(QubitDevice):
                 """Entry with args=(circuits=%s) called by=%s""",
                 circuits,
                 "::L".join(
-                    str(i) for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]
+                    str(i)
+                    for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]
                 ),
             )
 
@@ -262,7 +301,9 @@ class IonQDevice(QubitDevice):
         # Use tape-level shots if device shots are not set
         tape_shots = circuits[0].shots.total_shots if circuits[0].shots else None
         if self.shots is None and tape_shots is not None:
-            self.job["shots"] = tape_shots  # pylint: disable=access-member-before-definition
+            self.job["shots"] = (
+                tape_shots  # pylint: disable=access-member-before-definition
+            )
 
         for circuit_index, circuit in enumerate(circuits):
             self.check_validity(circuit.operations, circuit.observables)
@@ -277,7 +318,9 @@ class IonQDevice(QubitDevice):
             return [[] for _ in circuits]
 
         original_shots = self.shots  # pylint: disable=access-member-before-definition
-        original_shot_vector = self._shot_vector  # pylint: disable=access-member-before-definition
+        original_shot_vector = (
+            self._shot_vector
+        )  # pylint: disable=access-member-before-definition
 
         results = []
         for circuit_index, circuit in enumerate(circuits):
@@ -328,7 +371,9 @@ class IonQDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         if len(operations) == 0 and len(rotations) == 0:
-            warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
+            warnings.warn(
+                "Circuit is empty. Empty circuits return failures. Submitting anyway."
+            )
 
         for operation in operations:
             self._apply_operation(operation, circuit_index)
@@ -353,7 +398,9 @@ class IonQDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         if len(operations) == 0 and len(rotations) == 0:
-            warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
+            warnings.warn(
+                "Circuit is empty. Empty circuits return failures. Submitting anyway."
+            )
 
         for operation in operations:
             self._apply_operation(operation)
@@ -448,13 +495,19 @@ class IonQDevice(QubitDevice):
 
     def _remove_trivial_terms(self, terms, coefficients):
         """Removes all-identity (II..I) terms from the list of terms."""
-        filtered = [(t, c) for t, c in zip(terms, coefficients) if "X" in t or "Y" in t or "Z" in t]
+        filtered = [
+            (t, c)
+            for t, c in zip(terms, coefficients)
+            if "X" in t or "Y" in t or "Z" in t
+        ]
         if not filtered:
             return [], []
         terms, coefficients = zip(*filtered)
         return list(terms), list(coefficients)
 
-    def _decompose_evolution(self, operation, wires: list[int]) -> tuple[list[str], list[float]]:
+    def _decompose_evolution(
+        self, operation, wires: list[int]
+    ) -> tuple[list[str], list[float]]:
         """Decompose an Evolution gate's generator into IonQ Pauli terms and coefficients.
 
         Returns:
@@ -478,11 +531,15 @@ class IonQDevice(QubitDevice):
                     ops.extend(o)
                 else:
                     op_wires = scaled.wires.tolist()
-                    decomp = pauli_decompose(scaled.matrix(), wire_order=op_wires, pauli=False)
+                    decomp = pauli_decompose(
+                        scaled.matrix(), wire_order=op_wires, pauli=False
+                    )
                     coefficients.extend(decomp.coeffs.tolist())
                     ops.extend(decomp.ops)
         elif isinstance(generator, SparseHamiltonian):
-            decomp = pauli_decompose(generator.H.toarray(), wire_order=wires, pauli=False)
+            decomp = pauli_decompose(
+                generator.H.toarray(), wire_order=wires, pauli=False
+            )
             ops = decomp.ops
             coefficients = decomp.coeffs.tolist()
         elif isinstance(generator, SProd):
@@ -494,7 +551,9 @@ class IonQDevice(QubitDevice):
                 coefficients = [generator.scalar * float(c) for c in base_coeffs]
                 ops = base_ops
             elif isinstance(generator.base, Exp):
-                decomp = pauli_decompose(generator.matrix(), wire_order=wires, pauli=False)
+                decomp = pauli_decompose(
+                    generator.matrix(), wire_order=wires, pauli=False
+                )
                 ops = decomp.ops
                 coefficients = decomp.coeffs.tolist()
 
@@ -599,7 +658,9 @@ class IonQDevice(QubitDevice):
         # The IonQ API returns basis states using little-endian ordering.
         # Here, we rearrange the states to match the big-endian ordering
         # expected by PennyLane.
-        basis_states = (int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2) for k in histogram)
+        basis_states = (
+            int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2) for k in histogram
+        )
         idx = np.fromiter(basis_states, dtype=int)
 
         # convert the sparse probs into a probability array
@@ -618,7 +679,9 @@ class IonQDevice(QubitDevice):
         if shot_range is None and bin_size is None:
             return self.marginal_prob(self.prob, wires)
 
-        return self.estimate_probability(wires=wires, shot_range=shot_range, bin_size=bin_size)
+        return self.estimate_probability(
+            wires=wires, shot_range=shot_range, bin_size=bin_size
+        )
 
 
 class SimulatorDevice(IonQDevice):
@@ -642,7 +705,14 @@ class SimulatorDevice(IonQDevice):
             Defaults to None.
         api_key (str): The IonQ API key. If not provided, the environment
             variable ``IONQ_API_KEY`` is used.
-        noise (dict | None): {"model": str, "seed": int or None}. Defaults to None.
+        noise_model (str): the noise model to use for simulation. Valid values are ``"ideal"``,
+            ``"harmony"``, ``"aria-1"``, ``"aria-2"``, ``"forte-1"``, and ``"forte-enterprise-1"``.
+            Defaults to None (ideal simulation). See
+            `IonQ Simulation with Noise Models <https://docs.ionq.com/guides/simulation-with-noise-models>`_
+            for details.
+        noise_seed (int): seed for the noise model random number generator, for reproducible noisy
+            simulation results. Must be between 1 and 2^31. Only used when ``noise_model`` is set.
+            Defaults to None (random seed).
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
     """
 
@@ -658,8 +728,9 @@ class SimulatorDevice(IonQDevice):
         job_name=None,
         compilation=None,
         api_key=None,
+        noise_model=None,
+        noise_seed=None,
         dry_run=False,
-        noise=None,
         metadata=None,
     ):
         super().__init__(
@@ -670,8 +741,9 @@ class SimulatorDevice(IonQDevice):
             job_name=job_name,
             api_key=api_key,
             compilation=compilation,
+            noise_model=noise_model,
+            noise_seed=noise_seed,
             dry_run=dry_run,
-            noise=noise,
             metadata=metadata,
         )
 

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -226,17 +226,11 @@ class IonQDevice(QubitDevice):
             "gateset": self.gateset,
         }
         if circuits_array_length > 1:
-            self.input["circuits"] = [
-                {"circuit": []} for _ in range(circuits_array_length)
-            ]
+            self.input["circuits"] = [{"circuit": []} for _ in range(circuits_array_length)]
         else:
             self.input["circuit"] = []
         self.job = {
-            "type": (
-                "ionq.multi-circuit.v1"
-                if circuits_array_length > 1
-                else "ionq.circuit.v1"
-            ),
+            "type": ("ionq.multi-circuit.v1" if circuits_array_length > 1 else "ionq.circuit.v1"),
             "input": self.input,
             "backend": self.target,
         }
@@ -291,8 +285,7 @@ class IonQDevice(QubitDevice):
                 """Entry with args=(circuits=%s) called by=%s""",
                 circuits,
                 "::L".join(
-                    str(i)
-                    for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]
+                    str(i) for i in inspect.getouterframes(inspect.currentframe(), 2)[1][1:3]
                 ),
             )
 
@@ -301,9 +294,7 @@ class IonQDevice(QubitDevice):
         # Use tape-level shots if device shots are not set
         tape_shots = circuits[0].shots.total_shots if circuits[0].shots else None
         if self.shots is None and tape_shots is not None:
-            self.job["shots"] = (
-                tape_shots  # pylint: disable=access-member-before-definition
-            )
+            self.job["shots"] = tape_shots  # pylint: disable=access-member-before-definition
 
         for circuit_index, circuit in enumerate(circuits):
             self.check_validity(circuit.operations, circuit.observables)
@@ -318,9 +309,7 @@ class IonQDevice(QubitDevice):
             return [[] for _ in circuits]
 
         original_shots = self.shots  # pylint: disable=access-member-before-definition
-        original_shot_vector = (
-            self._shot_vector
-        )  # pylint: disable=access-member-before-definition
+        original_shot_vector = self._shot_vector  # pylint: disable=access-member-before-definition
 
         results = []
         for circuit_index, circuit in enumerate(circuits):
@@ -371,9 +360,7 @@ class IonQDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         if len(operations) == 0 and len(rotations) == 0:
-            warnings.warn(
-                "Circuit is empty. Empty circuits return failures. Submitting anyway."
-            )
+            warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
 
         for operation in operations:
             self._apply_operation(operation, circuit_index)
@@ -398,9 +385,7 @@ class IonQDevice(QubitDevice):
         rotations = kwargs.pop("rotations", [])
 
         if len(operations) == 0 and len(rotations) == 0:
-            warnings.warn(
-                "Circuit is empty. Empty circuits return failures. Submitting anyway."
-            )
+            warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
 
         for operation in operations:
             self._apply_operation(operation)
@@ -495,19 +480,13 @@ class IonQDevice(QubitDevice):
 
     def _remove_trivial_terms(self, terms, coefficients):
         """Removes all-identity (II..I) terms from the list of terms."""
-        filtered = [
-            (t, c)
-            for t, c in zip(terms, coefficients)
-            if "X" in t or "Y" in t or "Z" in t
-        ]
+        filtered = [(t, c) for t, c in zip(terms, coefficients) if "X" in t or "Y" in t or "Z" in t]
         if not filtered:
             return [], []
         terms, coefficients = zip(*filtered)
         return list(terms), list(coefficients)
 
-    def _decompose_evolution(
-        self, operation, wires: list[int]
-    ) -> tuple[list[str], list[float]]:
+    def _decompose_evolution(self, operation, wires: list[int]) -> tuple[list[str], list[float]]:
         """Decompose an Evolution gate's generator into IonQ Pauli terms and coefficients.
 
         Returns:
@@ -531,15 +510,11 @@ class IonQDevice(QubitDevice):
                     ops.extend(o)
                 else:
                     op_wires = scaled.wires.tolist()
-                    decomp = pauli_decompose(
-                        scaled.matrix(), wire_order=op_wires, pauli=False
-                    )
+                    decomp = pauli_decompose(scaled.matrix(), wire_order=op_wires, pauli=False)
                     coefficients.extend(decomp.coeffs.tolist())
                     ops.extend(decomp.ops)
         elif isinstance(generator, SparseHamiltonian):
-            decomp = pauli_decompose(
-                generator.H.toarray(), wire_order=wires, pauli=False
-            )
+            decomp = pauli_decompose(generator.H.toarray(), wire_order=wires, pauli=False)
             ops = decomp.ops
             coefficients = decomp.coeffs.tolist()
         elif isinstance(generator, SProd):
@@ -551,9 +526,7 @@ class IonQDevice(QubitDevice):
                 coefficients = [generator.scalar * float(c) for c in base_coeffs]
                 ops = base_ops
             elif isinstance(generator.base, Exp):
-                decomp = pauli_decompose(
-                    generator.matrix(), wire_order=wires, pauli=False
-                )
+                decomp = pauli_decompose(generator.matrix(), wire_order=wires, pauli=False)
                 ops = decomp.ops
                 coefficients = decomp.coeffs.tolist()
 
@@ -658,9 +631,7 @@ class IonQDevice(QubitDevice):
         # The IonQ API returns basis states using little-endian ordering.
         # Here, we rearrange the states to match the big-endian ordering
         # expected by PennyLane.
-        basis_states = (
-            int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2) for k in histogram
-        )
+        basis_states = (int(bin(int(k))[2:].rjust(self.num_wires, "0")[::-1], 2) for k in histogram)
         idx = np.fromiter(basis_states, dtype=int)
 
         # convert the sparse probs into a probability array
@@ -679,9 +650,7 @@ class IonQDevice(QubitDevice):
         if shot_range is None and bin_size is None:
             return self.marginal_prob(self.prob, wires)
 
-        return self.estimate_probability(
-            wires=wires, shot_range=shot_range, bin_size=bin_size
-        )
+        return self.estimate_probability(wires=wires, shot_range=shot_range, bin_size=bin_size)
 
 
 class SimulatorDevice(IonQDevice):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -376,6 +376,7 @@ class TestDeviceIntegration:
         "noise_model,noise_seed",
         [
             (None, None),
+            ("ideal", None),
             ("aria-1", None),
             ("harmony", None),
             ("forte-1", 42),
@@ -435,28 +436,25 @@ class TestDeviceIntegration:
         """Test that an invalid noise seed raises ValueError."""
         with pytest.raises(ValueError, match="noise_seed must be an integer"):
             qml.device(
-                "ionq.simulator",
-                wires=1,
-                api_key="test",
-                noise_model="aria-1",
-                noise_seed=0,
+                "ionq.simulator", wires=1, api_key="test", noise_model="aria-1", noise_seed=0
             )
         with pytest.raises(ValueError, match="noise_seed must be an integer"):
             qml.device(
-                "ionq.simulator",
-                wires=1,
-                api_key="test",
-                noise_model="aria-1",
-                noise_seed=-1,
+                "ionq.simulator", wires=1, api_key="test", noise_model="aria-1", noise_seed=-1
             )
         with pytest.raises(ValueError, match="noise_seed must be an integer"):
             qml.device(
-                "ionq.simulator",
-                wires=1,
-                api_key="test",
-                noise_model="aria-1",
-                noise_seed=2**31 + 1,
+                "ionq.simulator", wires=1, api_key="test", noise_model="aria-1", noise_seed=2**31
             )
+        with pytest.raises(ValueError, match="noise_seed must be an integer"):
+            qml.device(
+                "ionq.simulator", wires=1, api_key="test", noise_model="aria-1", noise_seed=True
+            )
+
+    def test_noise_seed_without_model(self):
+        """Test that noise_seed without noise_model raises ValueError."""
+        with pytest.raises(ValueError, match="noise_seed requires noise_model"):
+            qml.device("ionq.simulator", wires=1, api_key="test", noise_seed=42)
 
     @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_circuit(self, shots, requires_api, tol):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -60,15 +60,11 @@ class TestDevice:
 
         unique_outcomes1 = np.unique(sample1, axis=0)
         unique_outcomes2 = np.unique(sample2, axis=0)
-        assert np.all(
-            unique_outcomes1 == unique_outcomes2
-        )  # possible outcomes are the same
+        assert np.all(unique_outcomes1 == unique_outcomes2)  # possible outcomes are the same
 
         sorted_outcomes1 = np.sort(sample1, axis=0)
         sorted_outcomes2 = np.sort(sample2, axis=0)
-        assert np.all(
-            sorted_outcomes1 == sorted_outcomes2
-        )  # set of outcomes is the same
+        assert np.all(sorted_outcomes1 == sorted_outcomes2)  # set of outcomes is the same
 
 
 class TestDeviceIntegration:
@@ -117,9 +113,7 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(
-            ResourceManager, "handle_response", lambda self, response: None
-        )
+        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", False)
         monkeypatch.setattr(Job, "is_failed", True)
 
@@ -134,17 +128,13 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(
-            ResourceManager, "handle_response", lambda self, response: None
-        )
+        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(
-                self.resource, "data", type("data", tuple(), {"value": fake_json})()
-            )
+            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -166,17 +156,13 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(
-            ResourceManager, "handle_response", lambda self, response: None
-        )
+        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(
-                self.resource, "data", type("data", tuple(), {"value": fake_json})()
-            )
+            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -212,17 +198,13 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(
-            ResourceManager, "handle_response", lambda self, response: None
-        )
+        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(
-                self.resource, "data", type("data", tuple(), {"value": fake_json})()
-            )
+            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -254,17 +236,13 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(
-            ResourceManager, "handle_response", lambda self, response: None
-        )
+        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(
-                self.resource, "data", type("data", tuple(), {"value": fake_json})()
-            )
+            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -292,23 +270,17 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(
-            ResourceManager, "handle_response", lambda self, response: None
-        )
+        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(
-                self.resource, "data", type("data", tuple(), {"value": fake_json})()
-            )
+            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device(
-            "ionq.simulator", wires=1, job_name="test_name", api_key="test"
-        )
+        dev = qml.device("ionq.simulator", wires=1, job_name="test_name", api_key="test")
 
         @qml.qnode(dev, shots=1024)
         def circuit():
@@ -328,17 +300,13 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(
-            ResourceManager, "handle_response", lambda self, response: None
-        )
+        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(
-                self.resource, "data", type("data", tuple(), {"value": fake_json})()
-            )
+            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -358,34 +326,25 @@ class TestDeviceIntegration:
         spy = mocker.spy(requests, "post")
         circuit()
         if compilation is not None:
-            assert (
-                json.loads(spy.call_args[1]["data"])["settings"]["compilation"]
-                == compilation
-            )
+            assert json.loads(spy.call_args[1]["data"])["settings"]["compilation"] == compilation
         else:
             with pytest.raises(KeyError, match="settings"):
                 json.loads(spy.call_args[1]["data"])["settings"]
 
-    @pytest.mark.parametrize(
-        "error_mitigation", [None, {"debiasing": True}, {"debiasing": False}]
-    )
+    @pytest.mark.parametrize("error_mitigation", [None, {"debiasing": True}, {"debiasing": False}])
     def test_error_mitigation(self, error_mitigation, monkeypatch, mocker):
         """Test that error mitigation settings are properly handled when submitting a job to the API."""
 
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(
-            ResourceManager, "handle_response", lambda self, response: None
-        )
+        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(
-                self.resource, "data", type("data", tuple(), {"value": fake_json})()
-            )
+            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -429,17 +388,13 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(
-            ResourceManager, "handle_response", lambda self, response: None
-        )
+        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(
-                self.resource, "data", type("data", tuple(), {"value": fake_json})()
-            )
+            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -706,9 +661,7 @@ you want to access must be first set via the set_current_circuit_index device me
         assert results[0] == pytest.approx(-1, abs=0.1)
         assert results[1] == pytest.approx(0, abs=0.1)
 
-    def test_batch_execute_expectation_value_with_diagonalization_rotations(
-        self, requires_api
-    ):
+    def test_batch_execute_expectation_value_with_diagonalization_rotations(self, requires_api):
         """Test batch_execute method when computing expectation value of an
         observable that requires rotations for diagonalization."""
         dev = SimulatorDevice(wires=(0,), gateset="qis", shots=1024)
@@ -779,13 +732,9 @@ you want to access must be first set via the set_current_circuit_index device me
                 wires = list(range(len(state)))
                 super().__init__(wires=wires)
 
-            def process_samples(
-                self, samples, wire_order, shot_range=None, bin_size=None
-            ):
+            def process_samples(self, samples, wire_order, shot_range=None, bin_size=None):
                 counts_mp = qml.counts(wires=self._wires)
-                counts = counts_mp.process_samples(
-                    samples, wire_order, shot_range, bin_size
-                )
+                counts = counts_mp.process_samples(samples, wire_order, shot_range, bin_size)
                 return float(counts.get(self.state, 0))
 
             def process_counts(self, counts, wire_order):
@@ -1052,9 +1001,7 @@ class TestJobAttribute:
         def mock_submit_job(*args):
             raise StopExecute()
 
-        mocker.patch(
-            "pennylane_ionq.device.SimulatorDevice._submit_job", mock_submit_job
-        )
+        mocker.patch("pennylane_ionq.device.SimulatorDevice._submit_job", mock_submit_job)
         dev = SimulatorDevice(wires=(0,), gateset="native")
 
         with qml.tape.QuantumTape(shots=1024) as tape:
@@ -1092,9 +1039,7 @@ class TestJobAttribute:
         def mock_submit_job(*args):
             raise StopExecute()
 
-        mocker.patch(
-            "pennylane_ionq.device.SimulatorDevice._submit_job", mock_submit_job
-        )
+        mocker.patch("pennylane_ionq.device.SimulatorDevice._submit_job", mock_submit_job)
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
 
         with qml.tape.QuantumTape(shots=1024) as tape1:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -60,11 +60,15 @@ class TestDevice:
 
         unique_outcomes1 = np.unique(sample1, axis=0)
         unique_outcomes2 = np.unique(sample2, axis=0)
-        assert np.all(unique_outcomes1 == unique_outcomes2)  # possible outcomes are the same
+        assert np.all(
+            unique_outcomes1 == unique_outcomes2
+        )  # possible outcomes are the same
 
         sorted_outcomes1 = np.sort(sample1, axis=0)
         sorted_outcomes2 = np.sort(sample2, axis=0)
-        assert np.all(sorted_outcomes1 == sorted_outcomes2)  # set of outcomes is the same
+        assert np.all(
+            sorted_outcomes1 == sorted_outcomes2
+        )  # set of outcomes is the same
 
 
 class TestDeviceIntegration:
@@ -113,7 +117,9 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
+        monkeypatch.setattr(
+            ResourceManager, "handle_response", lambda self, response: None
+        )
         monkeypatch.setattr(Job, "is_complete", False)
         monkeypatch.setattr(Job, "is_failed", True)
 
@@ -128,13 +134,17 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
+        monkeypatch.setattr(
+            ResourceManager, "handle_response", lambda self, response: None
+        )
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
+            setattr(
+                self.resource, "data", type("data", tuple(), {"value": fake_json})()
+            )
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -156,13 +166,17 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
+        monkeypatch.setattr(
+            ResourceManager, "handle_response", lambda self, response: None
+        )
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
+            setattr(
+                self.resource, "data", type("data", tuple(), {"value": fake_json})()
+            )
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -198,20 +212,25 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
+        monkeypatch.setattr(
+            ResourceManager, "handle_response", lambda self, response: None
+        )
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
+            setattr(
+                self.resource, "data", type("data", tuple(), {"value": fake_json})()
+            )
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
         dev = qml.device(
             "ionq.simulator",
             wires=1,
-            noise={"model": "ideal", "seed": 7},
+            noise_model="ideal",
+            noise_seed=7,
             api_key="test",
         )
 
@@ -235,13 +254,17 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
+        monkeypatch.setattr(
+            ResourceManager, "handle_response", lambda self, response: None
+        )
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
+            setattr(
+                self.resource, "data", type("data", tuple(), {"value": fake_json})()
+            )
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -269,17 +292,23 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
+        monkeypatch.setattr(
+            ResourceManager, "handle_response", lambda self, response: None
+        )
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
+            setattr(
+                self.resource, "data", type("data", tuple(), {"value": fake_json})()
+            )
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device("ionq.simulator", wires=1, job_name="test_name", api_key="test")
+        dev = qml.device(
+            "ionq.simulator", wires=1, job_name="test_name", api_key="test"
+        )
 
         @qml.qnode(dev, shots=1024)
         def circuit():
@@ -299,13 +328,17 @@ class TestDeviceIntegration:
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
+        monkeypatch.setattr(
+            ResourceManager, "handle_response", lambda self, response: None
+        )
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
+            setattr(
+                self.resource, "data", type("data", tuple(), {"value": fake_json})()
+            )
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -325,25 +358,34 @@ class TestDeviceIntegration:
         spy = mocker.spy(requests, "post")
         circuit()
         if compilation is not None:
-            assert json.loads(spy.call_args[1]["data"])["settings"]["compilation"] == compilation
+            assert (
+                json.loads(spy.call_args[1]["data"])["settings"]["compilation"]
+                == compilation
+            )
         else:
             with pytest.raises(KeyError, match="settings"):
                 json.loads(spy.call_args[1]["data"])["settings"]
 
-    @pytest.mark.parametrize("error_mitigation", [None, {"debiasing": True}, {"debiasing": False}])
+    @pytest.mark.parametrize(
+        "error_mitigation", [None, {"debiasing": True}, {"debiasing": False}]
+    )
     def test_error_mitigation(self, error_mitigation, monkeypatch, mocker):
         """Test that error mitigation settings are properly handled when submitting a job to the API."""
 
         monkeypatch.setattr(
             requests, "post", lambda url, timeout, data, headers: (url, data, headers)
         )
-        monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
+        monkeypatch.setattr(
+            ResourceManager, "handle_response", lambda self, response: None
+        )
         monkeypatch.setattr(Job, "is_complete", True)
 
         def fake_response(self, resource_id=None, params=None):
             """Return fake response data"""
             fake_json = {"0": 1}
-            setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
+            setattr(
+                self.resource, "data", type("data", tuple(), {"value": fake_json})()
+            )
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
@@ -370,6 +412,96 @@ class TestDeviceIntegration:
         else:
             with pytest.raises(KeyError, match="settings"):
                 json.loads(spy.call_args[1]["data"])["settings"]
+
+    @pytest.mark.parametrize(
+        "noise_model,noise_seed",
+        [
+            (None, None),
+            ("aria-1", None),
+            ("harmony", None),
+            ("forte-1", 42),
+            ("aria-2", 12345),
+        ],
+    )
+    def test_noise_model(self, noise_model, noise_seed, monkeypatch, mocker):
+        """Test that noise model parameters are correctly sent in the job payload."""
+
+        monkeypatch.setattr(
+            requests, "post", lambda url, timeout, data, headers: (url, data, headers)
+        )
+        monkeypatch.setattr(
+            ResourceManager, "handle_response", lambda self, response: None
+        )
+        monkeypatch.setattr(Job, "is_complete", True)
+
+        def fake_response(self, resource_id=None, params=None):
+            """Return fake response data"""
+            fake_json = {"0": 1}
+            setattr(
+                self.resource, "data", type("data", tuple(), {"value": fake_json})()
+            )
+
+        monkeypatch.setattr(ResourceManager, "get", fake_response)
+
+        dev = qml.device(
+            "ionq.simulator",
+            wires=1,
+            api_key="test",
+            noise_model=noise_model,
+            noise_seed=noise_seed,
+        )
+
+        @qml.set_shots(5000)
+        @qml.qnode(dev)
+        def circuit():
+            """Reference QNode"""
+            qml.PauliX(wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        spy = mocker.spy(requests, "post")
+        circuit()
+        payload = json.loads(spy.call_args[1]["data"])
+
+        if noise_model is not None:
+            assert payload["noise"]["model"] == noise_model
+            if noise_seed is not None:
+                assert payload["noise"]["seed"] == noise_seed
+            else:
+                assert "seed" not in payload["noise"]
+        else:
+            assert "noise" not in payload
+
+    def test_noise_model_invalid(self):
+        """Test that an invalid noise model raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid noise model"):
+            qml.device("ionq.simulator", wires=1, api_key="test", noise_model="invalid")
+
+    def test_noise_seed_invalid(self):
+        """Test that an invalid noise seed raises ValueError."""
+        with pytest.raises(ValueError, match="noise_seed must be an integer"):
+            qml.device(
+                "ionq.simulator",
+                wires=1,
+                api_key="test",
+                noise_model="aria-1",
+                noise_seed=0,
+            )
+        with pytest.raises(ValueError, match="noise_seed must be an integer"):
+            qml.device(
+                "ionq.simulator",
+                wires=1,
+                api_key="test",
+                noise_model="aria-1",
+                noise_seed=-1,
+            )
+        with pytest.raises(ValueError, match="noise_seed must be an integer"):
+            qml.device(
+                "ionq.simulator",
+                wires=1,
+                api_key="test",
+                noise_model="aria-1",
+                noise_seed=2**31 + 1,
+            )
 
     @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_circuit(self, shots, requires_api, tol):
@@ -574,7 +706,9 @@ you want to access must be first set via the set_current_circuit_index device me
         assert results[0] == pytest.approx(-1, abs=0.1)
         assert results[1] == pytest.approx(0, abs=0.1)
 
-    def test_batch_execute_expectation_value_with_diagonalization_rotations(self, requires_api):
+    def test_batch_execute_expectation_value_with_diagonalization_rotations(
+        self, requires_api
+    ):
         """Test batch_execute method when computing expectation value of an
         observable that requires rotations for diagonalization."""
         dev = SimulatorDevice(wires=(0,), gateset="qis", shots=1024)
@@ -645,9 +779,13 @@ you want to access must be first set via the set_current_circuit_index device me
                 wires = list(range(len(state)))
                 super().__init__(wires=wires)
 
-            def process_samples(self, samples, wire_order, shot_range=None, bin_size=None):
+            def process_samples(
+                self, samples, wire_order, shot_range=None, bin_size=None
+            ):
                 counts_mp = qml.counts(wires=self._wires)
-                counts = counts_mp.process_samples(samples, wire_order, shot_range, bin_size)
+                counts = counts_mp.process_samples(
+                    samples, wire_order, shot_range, bin_size
+                )
                 return float(counts.get(self.state, 0))
 
             def process_counts(self, counts, wire_order):
@@ -914,7 +1052,9 @@ class TestJobAttribute:
         def mock_submit_job(*args):
             raise StopExecute()
 
-        mocker.patch("pennylane_ionq.device.SimulatorDevice._submit_job", mock_submit_job)
+        mocker.patch(
+            "pennylane_ionq.device.SimulatorDevice._submit_job", mock_submit_job
+        )
         dev = SimulatorDevice(wires=(0,), gateset="native")
 
         with qml.tape.QuantumTape(shots=1024) as tape:
@@ -952,7 +1092,9 @@ class TestJobAttribute:
         def mock_submit_job(*args):
             raise StopExecute()
 
-        mocker.patch("pennylane_ionq.device.SimulatorDevice._submit_job", mock_submit_job)
+        mocker.patch(
+            "pennylane_ionq.device.SimulatorDevice._submit_job", mock_submit_job
+        )
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
 
         with qml.tape.QuantumTape(shots=1024) as tape1:


### PR DESCRIPTION
Add noise_model and noise_seed parameters to SimulatorDevice for hardware-aware noisy simulation via the IonQ API.

```
dev = qml.device("ionq.simulator", wires=2, noise_model="aria-1", noise_seed=42)
```

This is a branch created to clone https://github.com/PennyLaneAI/PennyLane-IonQ/pull/171 in order to run all integration tests.