### PR TITLE
Stop using deprecated shots kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Improvements 🛠
 
+* Updated tests to stop using deprecated shots kwarg on the device.
+  [(#184)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/184)
+
 ### Breaking changes 💔
 
 ### Deprecations 👋
@@ -15,6 +18,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Marcus Edwards
 
 ---
 # Release 0.45.0

--- a/README.rst
+++ b/README.rst
@@ -107,8 +107,8 @@ You can instantiate the IonQ devices for PennyLane as follows:
 .. code-block:: python
 
     import pennylane as qml
-    dev1 = qml.device('ionq.simulator', wires=2, shots=1000)
-    dev2 = qml.device('ionq.qpu', backend='aria-1', wires=2, shots=1000)
+    dev1 = qml.device('ionq.simulator', wires=2)
+    dev2 = qml.device('ionq.qpu', backend='aria-1', wires=2)
 
 These devices can then be used just like other devices for the definition and evaluation of
 quantum circuits within PennyLane. For more details and ideas, see the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,15 +88,12 @@ def init_state(scope="session"):
 
 
 @pytest.fixture(params=analytic_devices + hw_devices)
-def device(request, shots):
+def device(request):
     """Fixture to initialize and return a PennyLane device"""
     device = request.param
 
-    if device not in analytic_devices and shots == 0:
-        pytest.skip("Hardware simulators do not support analytic mode")
-
     def _device(n):
-        return device(wires=n, shots=shots)
+        return device(wires=n)
 
     return _device
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -98,10 +98,10 @@ class TestDeviceIntegration:
             qml.device(d)
 
         # IonQ devices allow shots=None
-        dev = qml.device(d, wires=1, shots=None)
+        dev = qml.device(d, wires=1)
 
         # But the execution will raise error
-        @qml.qnode(dev)
+        @qml.qnode(dev, shots=None)
         def circuit():
             """Reference QNode"""
             qml.PauliX(wires=0)


### PR DESCRIPTION
We would like to update the tests to stop setting the shots on the device, which is deprecated.

This PR makes sure that shots are set on the qnode. There are no downsides.

[sc-101299]