### PR TITLE
Use `SpecsResources.num_wires` in tracker test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Upgraded Sphinx to version 9.0.
   [(#188)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/188)
 
+* Updated the tracker tests to use `SpecsResources.num_wires`, which replaces the
+  removed `num_allocs` attribute in PennyLane.
+  [(#191)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/191)
+
 ### Breaking changes 💔
 
 * Support for Python 3.11 has been removed.

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -548,11 +548,12 @@ class TestDeviceIntegration:
         assert dev.tracker.history["batches"] == [1]
         assert dev.tracker.history["batch_len"] == [2]
         assert len(dev.tracker.history["resources"]) == 2
-        assert dev.tracker.history["resources"][0].num_allocs == 1
-        assert dev.tracker.history["resources"][0].num_gates == 1
-        assert dev.tracker.history["resources"][0].depth == 1
-        assert dev.tracker.history["resources"][0].gate_types == {"GPI": 1}
-        assert dev.tracker.history["resources"][0].gate_sizes == {1: 1}
+        resources = dev.tracker.history["resources"][0]
+        assert resources.num_allocs == 1
+        assert resources.total_quantum_operations == 1
+        assert resources.depth == 1
+        assert resources.quantum_operations == {"GPI": 1}
+        assert resources.measurement_processes == {"probs(all wires)": 1}
         assert len(dev.tracker.history["results"]) == 2
 
     def test_not_recording_when_pennylane_tracker_not_active(self, requires_api):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -549,7 +549,7 @@ class TestDeviceIntegration:
         assert dev.tracker.history["batch_len"] == [2]
         assert len(dev.tracker.history["resources"]) == 2
         resources = dev.tracker.history["resources"][0]
-        assert resources.num_allocs == 1
+        assert resources.num_wires == 1
         assert resources.total_quantum_operations == 1
         assert resources.depth == 1
         assert resources.quantum_operations == {"GPI": 1}


### PR DESCRIPTION
**Context:**
PennyLane renamed `SpecsResources.num_allocs` back to `num_wires` and removed the alias ([PennyLaneAI/pennylane#9942](https://github.com/PennyLaneAI/pennylane/pull/9942)).

**Description of the Change:**
`TestDeviceIntegration::test_recording_when_pennylane_tracker_active` now asserts on `resources.num_wires`.

**Benefits:**
Fixes CI against latest PennyLane:
```
AttributeError: 'SpecsResources' object has no attribute 'num_allocs'
```

**Possible Drawbacks:**
The test now requires PennyLane with the `num_wires` field.

**Related GitHub Issues:**
None