### PR TITLE
[Fix] Update resource tracker with new names

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -548,12 +548,8 @@ class TestDeviceIntegration:
         assert dev.tracker.history["batches"] == [1]
         assert dev.tracker.history["batch_len"] == [2]
         assert len(dev.tracker.history["resources"]) == 2
-        resources = dev.tracker.history["resources"][0]
-        assert resources.num_allocs == 1
-        assert resources.total_quantum_operations == 1
-        assert resources.depth == 1
-        assert resources.quantum_operations == {"GPI": 1}
-        assert resources.measurement_processes == {"probs(all wires)": 1}
+        assert dev.tracker.history["resources"][0] == tape1.specs["resources"]
+        assert dev.tracker.history["resources"][1] == tape1.specs["resources"]
         assert len(dev.tracker.history["results"]) == 2
 
     def test_not_recording_when_pennylane_tracker_not_active(self, requires_api):


### PR DESCRIPTION
Fixes the following local test failure:
```py
❯     def test_recording_when_pennylane_tracker_active(self, requires_api):
          """Test recording device execution history via pennnylane tracker class."""
          dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
          dev.tracker = qp.Tracker()
          dev.tracker.active = True
          dev.tracker.reset()
          with qp.tape.QuantumTape(shots=1024) as tape1:
              GPI(0, wires=[0])
              qp.probs(wires=[0])
          dev.batch_execute([tape1, tape1])
          assert dev.tracker.history["executions"] == [1, 1]
          assert dev.tracker.history["shots"] == [1024, 1024]
          assert dev.tracker.history["batches"] == [1]
          assert dev.tracker.history["batch_len"] == [2]
          assert len(dev.tracker.history["resources"]) == 2
          resources = dev.tracker.history["resources"][0]
          assert resources.num_allocs == 1
  >       assert resources.total_quantum_operations == 1
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  E       AttributeError: 'SpecsResources' object has no attribute 'total_quantum_operations'
```

``pennylane==0.45.1`` and GH `master` branch of PennyLane-IonQ.