### PR TITLE
[Feat] Mid-circuit measurement and qubit reset support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### New features since last release
 
+* Added support for mid-circuit measurements and qubit reset via `qp.measure`.
+  Such circuits are converted to OpenQASM 3.0 and submitted as `ionq.qasm3.v1` jobs.
+  [(#193)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/193)
+
 ### Improvements 🛠
 
 * Updated tests to stop using deprecated shots kwarg on the device.
@@ -27,7 +31,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Marcus Edwards
+Antal Száva, Marcus Edwards
 
 ---
 # Release 0.45.0

--- a/doc/devices.rst
+++ b/doc/devices.rst
@@ -80,6 +80,43 @@ Both devices support the same set of operations.
 .. raw::html
     </section>
 
+Mid-circuit measurements and qubit reset
+----------------------------------------
+
+Both devices support mid-circuit measurements via
+:func:`qp.measure <pennylane.measure>`. When a circuit contains a mid-circuit
+measurement, the plugin converts it to an OpenQASM 3.0 program and submits it
+through IonQ's ``ionq.qasm3.v1`` job type instead of the flat gate-list format:
+
+.. code-block:: python
+
+    import pennylane as qp
+
+    dev = qp.device("ionq.simulator", wires=1)
+
+    @qp.set_shots(1024)
+    @qp.qnode(dev)
+    def circuit():
+        qp.Hadamard(wires=0)
+        qp.measure(0, reset=True)
+        qp.PauliX(wires=0)
+        return qp.probs(wires=[0])
+
+Measuring with ``reset=True`` emits an explicit ``reset`` statement in the
+generated OpenQASM 3.0 program.
+
+The following restrictions apply:
+
+* Postselection (``qp.measure(0, postselect=1)``) is not supported.
+
+* Classically controlled operations (:func:`qp.cond <pennylane.cond>`) are not
+  supported. Apply :func:`qp.defer_measurements <pennylane.defer_measurements>`
+  to the circuit (or use ``mcm_method="deferred"``) to convert conditionals to
+  controlled gates.
+
+* Circuits with mid-circuit measurements must be submitted one at a time; they
+  cannot be part of a batch submission.
+
 IonQ Operations
 ---------------
 

--- a/pennylane_ionq/__init__.py
+++ b/pennylane_ionq/__init__.py
@@ -18,5 +18,4 @@ PennyLane IonQ overview
 
 from .ops import GPI, GPI2, MS, XX, YY, ZZ
 from .device import SimulatorDevice, QPUDevice
-from .qasm3 import to_qasm3
 from ._version import __version__

--- a/pennylane_ionq/__init__.py
+++ b/pennylane_ionq/__init__.py
@@ -18,4 +18,5 @@ PennyLane IonQ overview
 
 from .ops import GPI, GPI2, MS, XX, YY, ZZ
 from .device import SimulatorDevice, QPUDevice
+from .qasm3 import to_qasm3
 from ._version import __version__

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -91,8 +91,8 @@ PAULI_MAP = {"PauliX": "X", "PauliY": "Y", "PauliZ": "Z", "Identity": "I"}
 NO_ANALYTIC_MSG = "The ionq device does not support analytic expectation values."
 
 NO_CONDITIONAL_MSG = (
-    "Classically controlled operations (qml.cond) are not supported by the "
-    "IonQ device. Apply qml.defer_measurements to the circuit (or use "
+    "Classically controlled operations (qp.cond) are not supported by the "
+    "IonQ device. Apply qp.defer_measurements to the circuit (or use "
     'mcm_method="deferred") to convert conditionals to controlled gates.'
 )
 
@@ -113,7 +113,7 @@ def circuit_requires_qasm3(circuit):
 
     Raises:
         ValueError: if the circuit contains a classically controlled
-            operation (``qml.cond``), which is not supported
+            operation (``qp.cond``), which is not supported
     """
     operations = list(getattr(circuit, "operations", circuit))
     if any(isinstance(operation, Conditional) for operation in operations):
@@ -462,7 +462,7 @@ class IonQDevice(QubitDevice):
 
         Extends the default to accept mid-circuit measurements, which are
         submitted via the qasm3 path. Classically controlled operations
-        (``qml.cond``) are also accepted here so that they reach the device
+        (``qp.cond``) are also accepted here so that they reach the device
         intact and are rejected with a clear error instead of a failed
         decomposition.
         """

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -35,6 +35,7 @@ from pennylane.tape import QuantumScript
 from pennylane.ops.op_math.linear_combination import LinearCombination
 
 from .api_client import Job, JobExecutionError
+from .qasm3 import operations_to_qasm3
 from .exceptions import (
     CircuitIndexNotSetException,
     ComplexEvolutionCoefficientsNotSupported,
@@ -89,74 +90,43 @@ PAULI_MAP = {"PauliX": "X", "PauliY": "Y", "PauliZ": "Z", "Identity": "I"}
 
 NO_ANALYTIC_MSG = "The ionq device does not support analytic expectation values."
 
-# OpenQASM 3 (stdgates.inc) spellings for the operations supported on the
-# ionq.qasm3.v1 submission path.
-_qasm3_gate_map = {
-    "PauliX": "x",
-    "PauliY": "y",
-    "PauliZ": "z",
-    "Hadamard": "h",
-    "CNOT": "cx",
-    "SWAP": "swap",
-    "RX": "rx",
-    "RY": "ry",
-    "RZ": "rz",
-    "S": "s",
-    "S.inv": "sdg",
-    "Adjoint(S)": "sdg",
-    "T": "t",
-    "T.inv": "tdg",
-    "Adjoint(T)": "tdg",
-    "SX": "sx",
-}
+NO_CONDITIONAL_MSG = (
+    "Classically controlled operations (qml.cond) are not supported by the "
+    "IonQ device. Apply qml.defer_measurements to the circuit (or use "
+    'mcm_method="deferred") to convert conditionals to controlled gates.'
+)
 
 
 def circuit_requires_qasm3(circuit):
     """Whether a circuit must be submitted as an ``ionq.qasm3.v1`` job.
 
-    True for circuits with a mid-circuit reset, classically controlled
-    operations, or a gate acting on a previously measured wire (qubit reuse);
-    these are not expressible as a flat ``ionq.circuit.v1`` gate list and are
-    submitted as an OpenQASM 3 program instead.
+    True for circuits with a mid-circuit reset or a gate acting on a
+    previously measured wire (qubit reuse); these are not expressible as a
+    flat ``ionq.circuit.v1`` gate list and are submitted as an OpenQASM 3
+    program instead.
 
     Args:
         circuit (QuantumTape or Iterable[Operation]): a tape, or its operations
 
     Returns:
         bool: whether the qasm3 submission path is required
+
+    Raises:
+        ValueError: if the circuit contains a classically controlled
+            operation (``qml.cond``), which is not supported
     """
-    operations = getattr(circuit, "operations", circuit)
+    operations = list(getattr(circuit, "operations", circuit))
+    if any(isinstance(operation, Conditional) for operation in operations):
+        raise ValueError(NO_CONDITIONAL_MSG)
     measured = set()
     for operation in operations:
-        if isinstance(operation, Conditional):
-            return True
         if isinstance(operation, MidMeasureMP):
-            if operation.reset:
-                return True
-            measured.update(operation.wires)
-            continue
+            return True
         if operation.name in ("Barrier", "Snapshot"):
             continue
         if measured.intersection(operation.wires):
             return True
     return False
-
-
-def _qasm3_condition(meas_val, bit_indices):
-    """Render a ``MeasurementValue`` as an OpenQASM 3 boolean expression over
-    the ``mid`` bit register by enumerating the value's branches.
-
-    Returns an empty string if no branch is truthy (the conditional is dead).
-    """
-    bits = [bit_indices[id(measurement)] for measurement in meas_val.measurements]
-    terms = []
-    for assignment, outcome in meas_val.branches.items():
-        if outcome:
-            clauses = " && ".join(
-                f"mid[{bit}] == {int(value)}" for bit, value in zip(bits, assignment)
-            )
-            terms.append(f"({clauses})" if len(bits) > 1 else clauses)
-    return " || ".join(terms)
 
 
 class IonQDevice(QubitDevice):
@@ -388,8 +358,8 @@ class IonQDevice(QubitDevice):
         if any(circuit_requires_qasm3(circuit) for circuit in circuits):
             if len(circuits) > 1:
                 raise ValueError(
-                    "Mid-circuit measurement, reset, and classical control flow "
-                    "require a single-circuit job; submit these circuits one at a time."
+                    "Mid-circuit measurement and reset require a single-circuit "
+                    "job; submit these circuits one at a time."
                 )
 
         self.reset(circuits_array_length=len(circuits))
@@ -490,8 +460,11 @@ class IonQDevice(QubitDevice):
     def stopping_condition(self):
         """.BooleanFn: Returns the stopping condition for the device.
 
-        Extends the default to accept mid-circuit measurements and classically
-        controlled operations, which are submitted via the qasm3 path.
+        Extends the default to accept mid-circuit measurements, which are
+        submitted via the qasm3 path. Classically controlled operations
+        (``qml.cond``) are also accepted here so that they reach the device
+        intact and are rejected with a clear error instead of a failed
+        decomposition.
         """
 
         def accepts_obj(obj):
@@ -534,64 +507,19 @@ class IonQDevice(QubitDevice):
         """
         self.input = {
             "qubits": self.num_wires,
-            "data": self._to_openqasm3(operations),
+            "data": operations_to_qasm3(operations, wires=self.wires, gateset=self.gateset),
         }
         self.job["type"] = "ionq.qasm3.v1"
         self.job["input"] = self.input
 
-    def _to_openqasm3(self, operations):
-        """Serializes operations (including mid-circuit measurements, resets
-        and classically controlled gates) to an OpenQASM 3 program.
-
-        Mid-circuit measurement outcomes are recorded in a single ``mid`` bit
-        register, one bit per measurement in circuit order.
-        """
-        mid_measurements = [
-            operation for operation in operations if isinstance(operation, MidMeasureMP)
-        ]
-        bit_indices = {id(operation): index for index, operation in enumerate(mid_measurements)}
-
-        lines = [
-            "OPENQASM 3.0;",
-            'include "stdgates.inc";',
-            f"qubit[{self.num_wires}] q;",
-        ]
-        if mid_measurements:
-            lines.append(f"bit[{len(mid_measurements)}] mid;")
-
-        for operation in operations:
-            if isinstance(operation, MidMeasureMP):
-                wire = self.map_wires(operation.wires).tolist()[0]
-                lines.append(f"mid[{bit_indices[id(operation)]}] = measure q[{wire}];")
-                if operation.reset:
-                    lines.append(f"reset q[{wire}];")
-            elif isinstance(operation, Conditional):
-                condition = _qasm3_condition(operation.meas_val, bit_indices)
-                if condition:
-                    lines.append(f"if ({condition}) {{")
-                    lines.append(f"    {self._qasm3_gate(operation.base)}")
-                    lines.append("}")
-            elif operation.name in ("Barrier", "Snapshot"):
-                continue
-            else:
-                lines.append(self._qasm3_gate(operation))
-        return "\n".join(lines) + "\n"
-
-    def _qasm3_gate(self, operation):
-        """Renders a single gate operation as an OpenQASM 3 statement."""
-        gate = _qasm3_gate_map.get(operation.name)
-        if gate is None:
-            raise ValueError(
-                f"Gate {operation.name} is not supported on the OpenQASM 3 submission "
-                "path used for circuits with mid-circuit measurements, resets, or "
-                "classical control flow."
-            )
-        wires = self.map_wires(operation.wires).tolist()
-        targets = ", ".join(f"q[{wire}]" for wire in wires)
-        if operation.parameters:
-            params = ", ".join(repr(float(param)) for param in operation.parameters)
-            return f"{gate}({params}) {targets};"
-        return f"{gate} {targets};"
+        # OpenQASM 3 jobs need the v0.4 compiler stack to return
+        # register-named results; pin it unless the caller set their own
+        # service_version via the compilation setting.
+        settings = dict(self.job.get("settings") or {})
+        compilation = dict(settings.get("compilation") or {})
+        compilation.setdefault("service_version", "v0.4")
+        settings["compilation"] = compilation
+        self.job["settings"] = settings
 
     def _apply_operation(self, operation, circuit_index=0):
         """Applies operations to the internal device state.

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -24,11 +24,13 @@ from time import sleep
 
 import numpy as np
 
-from pennylane import pauli_decompose, SparseHamiltonian
+from pennylane import BooleanFn, pauli_decompose, SparseHamiltonian
 from pennylane.devices import QubitDevice
-from pennylane.ops.op_math import Exp, Sum, SProd
+from pennylane.measurements import MeasurementProcess, MidMeasureMP
+from pennylane.ops.op_math import Conditional, Exp, Sum, SProd
 from pennylane.ops import Identity, PauliX, PauliY, PauliZ
 from pennylane.ops.op_math.prod import Prod
+from pennylane.tape import QuantumScript
 
 from pennylane.ops.op_math.linear_combination import LinearCombination
 
@@ -86,6 +88,75 @@ _GATESET_OPS = {
 PAULI_MAP = {"PauliX": "X", "PauliY": "Y", "PauliZ": "Z", "Identity": "I"}
 
 NO_ANALYTIC_MSG = "The ionq device does not support analytic expectation values."
+
+# OpenQASM 3 (stdgates.inc) spellings for the operations supported on the
+# ionq.qasm3.v1 submission path.
+_qasm3_gate_map = {
+    "PauliX": "x",
+    "PauliY": "y",
+    "PauliZ": "z",
+    "Hadamard": "h",
+    "CNOT": "cx",
+    "SWAP": "swap",
+    "RX": "rx",
+    "RY": "ry",
+    "RZ": "rz",
+    "S": "s",
+    "S.inv": "sdg",
+    "Adjoint(S)": "sdg",
+    "T": "t",
+    "T.inv": "tdg",
+    "Adjoint(T)": "tdg",
+    "SX": "sx",
+}
+
+
+def circuit_requires_qasm3(circuit):
+    """Whether a circuit must be submitted as an ``ionq.qasm3.v1`` job.
+
+    True for circuits with a mid-circuit reset, classically controlled
+    operations, or a gate acting on a previously measured wire (qubit reuse);
+    these are not expressible as a flat ``ionq.circuit.v1`` gate list and are
+    submitted as an OpenQASM 3 program instead.
+
+    Args:
+        circuit (QuantumTape or Iterable[Operation]): a tape, or its operations
+
+    Returns:
+        bool: whether the qasm3 submission path is required
+    """
+    operations = getattr(circuit, "operations", circuit)
+    measured = set()
+    for operation in operations:
+        if isinstance(operation, Conditional):
+            return True
+        if isinstance(operation, MidMeasureMP):
+            if operation.reset:
+                return True
+            measured.update(operation.wires)
+            continue
+        if operation.name in ("Barrier", "Snapshot"):
+            continue
+        if measured.intersection(operation.wires):
+            return True
+    return False
+
+
+def _qasm3_condition(meas_val, bit_indices):
+    """Render a ``MeasurementValue`` as an OpenQASM 3 boolean expression over
+    the ``mid`` bit register by enumerating the value's branches.
+
+    Returns an empty string if no branch is truthy (the conditional is dead).
+    """
+    bits = [bit_indices[id(measurement)] for measurement in meas_val.measurements]
+    terms = []
+    for assignment, outcome in meas_val.branches.items():
+        if outcome:
+            clauses = " && ".join(
+                f"mid[{bit}] == {int(value)}" for bit, value in zip(bits, assignment)
+            )
+            terms.append(f"({clauses})" if len(bits) > 1 else clauses)
+    return " || ".join(terms)
 
 
 class IonQDevice(QubitDevice):
@@ -152,6 +223,7 @@ class IonQDevice(QubitDevice):
         "model": "qubit",
         "tensor_observables": True,
         "inverse_operations": True,
+        "supports_mid_measure": True,
     }
 
     # Note: unlike QubitDevice, IonQ does not support QubitUnitary,
@@ -289,7 +361,7 @@ class IonQDevice(QubitDevice):
         """
         self._current_circuit_index = circuit_index
 
-    def batch_execute(self, circuits):
+    def batch_execute(self, circuits, postselect_mode=None):
         """Execute a batch of quantum circuits on the device.
 
         The circuits are represented by tapes, and they are executed one-by-one using the
@@ -297,6 +369,9 @@ class IonQDevice(QubitDevice):
 
         Args:
             circuits (list[~.tape.QuantumTape]): circuits to execute on the device
+            postselect_mode (str | None): passed by PennyLane for devices that
+                support mid-circuit measurements; postselection is not
+                supported on IonQ hardware, so the argument is ignored
 
         Returns:
             list[array[float]]: list of measured value(s)
@@ -310,6 +385,13 @@ class IonQDevice(QubitDevice):
                 ),
             )
 
+        if any(circuit_requires_qasm3(circuit) for circuit in circuits):
+            if len(circuits) > 1:
+                raise ValueError(
+                    "Mid-circuit measurement, reset, and classical control flow "
+                    "require a single-circuit job; submit these circuits one at a time."
+                )
+
         self.reset(circuits_array_length=len(circuits))
 
         # Use tape-level shots if device shots are not set
@@ -319,11 +401,16 @@ class IonQDevice(QubitDevice):
 
         for circuit_index, circuit in enumerate(circuits):
             self.check_validity(circuit.operations, circuit.observables)
-            self.batch_apply(
-                circuit.operations,
-                rotations=self._get_diagonalizing_gates(circuit),
-                circuit_index=circuit_index,
-            )
+            if circuit_requires_qasm3(circuit):
+                self._apply_qasm3(
+                    list(circuit.operations) + list(self._get_diagonalizing_gates(circuit))
+                )
+            else:
+                self.batch_apply(
+                    circuit.operations,
+                    rotations=self._get_diagonalizing_gates(circuit),
+                    circuit_index=circuit_index,
+                )
         self._submit_job()
 
         if self.dry_run:
@@ -399,6 +486,25 @@ class IonQDevice(QubitDevice):
         """
         return set(self._operation_map.keys())
 
+    @property
+    def stopping_condition(self):
+        """.BooleanFn: Returns the stopping condition for the device.
+
+        Extends the default to accept mid-circuit measurements and classically
+        controlled operations, which are submitted via the qasm3 path.
+        """
+
+        def accepts_obj(obj):
+            if isinstance(obj, MidMeasureMP):
+                return True
+            if isinstance(obj, Conditional):
+                return accepts_obj(obj.base)
+            return not isinstance(obj, QuantumScript) and (
+                isinstance(obj, MeasurementProcess) or self.supports_operation(obj.name)
+            )
+
+        return BooleanFn(accepts_obj)
+
     def apply(self, operations, **kwargs):
         """Implementation of QubitDevice abstract method apply."""
 
@@ -408,14 +514,84 @@ class IonQDevice(QubitDevice):
         if len(operations) == 0 and len(rotations) == 0:
             warnings.warn("Circuit is empty. Empty circuits return failures. Submitting anyway.")
 
-        for operation in operations:
-            self._apply_operation(operation)
+        if circuit_requires_qasm3(operations):
+            self._apply_qasm3(list(operations) + list(rotations))
+        else:
+            for operation in operations:
+                self._apply_operation(operation)
 
-        # diagonalize observables
-        for operation in rotations:
-            self._apply_operation(operation)
+            # diagonalize observables
+            for operation in rotations:
+                self._apply_operation(operation)
 
         self._submit_job()
+
+    def _apply_qasm3(self, operations):
+        """Turns the job prepared by ``reset`` into an ``ionq.qasm3.v1`` job.
+
+        Job-level fields (shots, name, noise, settings, metadata, ...) are kept
+        as assembled by ``reset``; only the type and input are replaced.
+        """
+        self.input = {
+            "qubits": self.num_wires,
+            "data": self._to_openqasm3(operations),
+        }
+        self.job["type"] = "ionq.qasm3.v1"
+        self.job["input"] = self.input
+
+    def _to_openqasm3(self, operations):
+        """Serializes operations (including mid-circuit measurements, resets
+        and classically controlled gates) to an OpenQASM 3 program.
+
+        Mid-circuit measurement outcomes are recorded in a single ``mid`` bit
+        register, one bit per measurement in circuit order.
+        """
+        mid_measurements = [
+            operation for operation in operations if isinstance(operation, MidMeasureMP)
+        ]
+        bit_indices = {id(operation): index for index, operation in enumerate(mid_measurements)}
+
+        lines = [
+            "OPENQASM 3.0;",
+            'include "stdgates.inc";',
+            f"qubit[{self.num_wires}] q;",
+        ]
+        if mid_measurements:
+            lines.append(f"bit[{len(mid_measurements)}] mid;")
+
+        for operation in operations:
+            if isinstance(operation, MidMeasureMP):
+                wire = self.map_wires(operation.wires).tolist()[0]
+                lines.append(f"mid[{bit_indices[id(operation)]}] = measure q[{wire}];")
+                if operation.reset:
+                    lines.append(f"reset q[{wire}];")
+            elif isinstance(operation, Conditional):
+                condition = _qasm3_condition(operation.meas_val, bit_indices)
+                if condition:
+                    lines.append(f"if ({condition}) {{")
+                    lines.append(f"    {self._qasm3_gate(operation.base)}")
+                    lines.append("}")
+            elif operation.name in ("Barrier", "Snapshot"):
+                continue
+            else:
+                lines.append(self._qasm3_gate(operation))
+        return "\n".join(lines) + "\n"
+
+    def _qasm3_gate(self, operation):
+        """Renders a single gate operation as an OpenQASM 3 statement."""
+        gate = _qasm3_gate_map.get(operation.name)
+        if gate is None:
+            raise ValueError(
+                f"Gate {operation.name} is not supported on the OpenQASM 3 submission "
+                "path used for circuits with mid-circuit measurements, resets, or "
+                "classical control flow."
+            )
+        wires = self.map_wires(operation.wires).tolist()
+        targets = ", ".join(f"q[{wire}]" for wire in wires)
+        if operation.parameters:
+            params = ", ".join(repr(float(param)) for param in operation.parameters)
+            return f"{gate}({params}) {targets};"
+        return f"{gate} {targets};"
 
     def _apply_operation(self, operation, circuit_index=0):
         """Applies operations to the internal device state.

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -341,8 +341,7 @@ class IonQDevice(QubitDevice):
         """
         if postselect_mode is not None:
             warnings.warn(
-                "'postselect_mode' is ignored: postselection is not supported "
-                "on IonQ hardware.",
+                "'postselect_mode' is ignored: postselection is not supported " "on IonQ hardware.",
                 UserWarning,
             )
         if logger.isEnabledFor(logging.DEBUG):

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -333,11 +333,18 @@ class IonQDevice(QubitDevice):
             circuits (list[~.tape.QuantumTape]): circuits to execute on the device
             postselect_mode (str | None): passed by PennyLane for devices that
                 support mid-circuit measurements; postselection is not
-                supported on IonQ hardware, so the argument is ignored
+                supported on IonQ hardware, so the argument has no effect and
+                a ``UserWarning`` is raised if it is explicitly set
 
         Returns:
             list[array[float]]: list of measured value(s)
         """
+        if postselect_mode is not None:
+            warnings.warn(
+                "'postselect_mode' is ignored: postselection is not supported "
+                "on IonQ hardware.",
+                UserWarning,
+            )
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(  # pragma: no cover
                 """Entry with args=(circuits=%s) called by=%s""",

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -347,12 +347,14 @@ class IonQDevice(QubitDevice):
                 ),
             )
 
+        requires_qasm3 = False
         if any(circuit_requires_qasm3(circuit) for circuit in circuits):
-            if len(circuits) > 1:
+            if len(circuits) != 1:
                 raise ValueError(
                     "Mid-circuit measurement and reset require a single-circuit "
                     "job; submit these circuits one at a time."
                 )
+            requires_qasm3 = True
 
         self.reset(circuits_array_length=len(circuits))
 
@@ -361,18 +363,22 @@ class IonQDevice(QubitDevice):
         if self.shots is None and tape_shots is not None:
             self.job["shots"] = tape_shots  # pylint: disable=access-member-before-definition
 
-        for circuit_index, circuit in enumerate(circuits):
-            self.check_validity(circuit.operations, circuit.observables)
-            if circuit_requires_qasm3(circuit):
-                self._apply_qasm3(
-                    list(circuit.operations) + list(self._get_diagonalizing_gates(circuit))
-                )
-            else:
+        if not requires_qasm3:
+            for circuit_index, circuit in enumerate(circuits):
+                self.check_validity(circuit.operations, circuit.observables)
                 self.batch_apply(
                     circuit.operations,
                     rotations=self._get_diagonalizing_gates(circuit),
                     circuit_index=circuit_index,
                 )
+        else:
+            # Only single-circuit submission is support for qasm3
+            circuit = circuits[0]
+            self.check_validity(circuit.operations, circuit.observables)
+            self._apply_qasm3(
+                list(circuit.operations) + list(self._get_diagonalizing_gates(circuit))
+            )
+
         self._submit_job()
 
         if self.dry_run:

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -100,9 +100,9 @@ NO_CONDITIONAL_MSG = (
 def circuit_requires_qasm3(circuit):
     """Whether a circuit must be submitted as an ``ionq.qasm3.v1`` job.
 
-    True for circuits with a mid-circuit reset or a gate acting on a
-    previously measured wire (qubit reuse); these are not expressible as a
-    flat ``ionq.circuit.v1`` gate list and are submitted as an OpenQASM 3
+    True for circuits containing a mid-circuit measurement (including
+    measurements with reset); these are not expressible as a flat
+    ``ionq.circuit.v1`` gate list and are submitted as an OpenQASM 3
     program instead.
 
     Args:
@@ -118,15 +118,7 @@ def circuit_requires_qasm3(circuit):
     operations = list(getattr(circuit, "operations", circuit))
     if any(isinstance(operation, Conditional) for operation in operations):
         raise ValueError(NO_CONDITIONAL_MSG)
-    measured = set()
-    for operation in operations:
-        if isinstance(operation, MidMeasureMP):
-            return True
-        if operation.name in ("Barrier", "Snapshot"):
-            continue
-        if measured.intersection(operation.wires):
-            return True
-    return False
+    return any(isinstance(operation, MidMeasureMP) for operation in operations)
 
 
 class IonQDevice(QubitDevice):

--- a/pennylane_ionq/ops.py
+++ b/pennylane_ionq/ops.py
@@ -17,6 +17,7 @@ Custom operations
 
 import numpy as np
 from pennylane.operation import Operation
+from pennylane.ops import IsingXX, IsingYY, IsingZZ
 
 
 # Custom operations for the native gateset below.
@@ -145,6 +146,10 @@ class XX(Operation):
     num_wires = 2
     grad_method = "A"
 
+    @staticmethod
+    def compute_decomposition(phi, wires):  # pylint: disable=arguments-differ
+        return [IsingXX(phi, wires=wires)]
+
 
 class YY(Operation):
     r"""YY(phi, wires)
@@ -168,6 +173,10 @@ class YY(Operation):
     num_wires = 2
     grad_method = "A"
 
+    @staticmethod
+    def compute_decomposition(phi, wires):  # pylint: disable=arguments-differ
+        return [IsingYY(phi, wires=wires)]
+
 
 class ZZ(Operation):
     r"""ZZ(phi, wires)
@@ -190,3 +199,7 @@ class ZZ(Operation):
     num_params = 1
     num_wires = 2
     grad_method = "A"
+
+    @staticmethod
+    def compute_decomposition(phi, wires):  # pylint: disable=arguments-differ
+        return [IsingZZ(phi, wires=wires)]

--- a/pennylane_ionq/qasm3.py
+++ b/pennylane_ionq/qasm3.py
@@ -1,0 +1,349 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Conversion of a circuit to an OpenQASM 3.0 program.
+
+Adapted from ``pennylane.io.to_openqasm`` (PennyLane, Apache License 2.0):
+https://github.com/PennyLaneAI/pennylane/blob/master/pennylane/io/to_openqasm.py
+
+Changes from the original:
+
+- Emits OpenQASM 3.0 syntax instead of OpenQASM 2.0 (``qubit[]``/``bit[]``
+  declarations, assignment-form measurement, explicit ``reset``).
+- Mid-circuit measurements with ``reset=True`` are supported (qubit reuse)
+  instead of raising ``NotImplementedError``.
+- Supports the IonQ native gateset (``gpi``/``gpi2``/``ms``), whose gates
+  IonQ accepts directly in OpenQASM 3.0 programs with parameters in turns.
+- Classically controlled operations (``qml.cond``) are intentionally not
+  supported; this exporter is scoped to mid-circuit measurement and qubit
+  reuse only. Circuits containing a ``Conditional`` raise ``ValueError``.
+"""
+
+from functools import singledispatch, wraps
+
+from pennylane.devices.preprocess import decompose
+from pennylane.operation import Operator
+from pennylane.ops import MidMeasure
+from pennylane.tape import QuantumScript
+from pennylane.transforms import convert_to_numpy_parameters
+from pennylane.wires import Wires, WiresLike
+from pennylane.workflow import construct_tape
+
+OPENQASM_GATES = {
+    "CNOT": "cx",
+    "CZ": "cz",
+    "U3": "u3",
+    "U2": "u2",
+    "U1": "u1",
+    "Identity": "id",
+    "PauliX": "x",
+    "PauliY": "y",
+    "PauliZ": "z",
+    "Hadamard": "h",
+    "S": "s",
+    "Adjoint(S)": "sdg",
+    "T": "t",
+    "Adjoint(T)": "tdg",
+    "SX": "sx",
+    "RX": "rx",
+    "RY": "ry",
+    "RZ": "rz",
+    "CRX": "crx",
+    "CRY": "cry",
+    "CRZ": "crz",
+    "SWAP": "swap",
+    "Toffoli": "ccx",
+    "CSWAP": "cswap",
+    "PhaseShift": "u1",
+    "GlobalPhase": "gphase",
+}
+"""dict[str, str]: Maps PennyLane gate names to OpenQASM 3 gate names.
+
+``gphase`` is a QASM 3 builtin; all other gates are defined in stdgates.inc,
+which keeps the ``u1``/``u2``/``u3`` spellings for backwards compatibility.
+"""
+
+NATIVE_QASM3_GATES = {
+    "GPI": "gpi",
+    "GPI2": "gpi2",
+    "MS": "ms",
+}
+"""dict[str, str]: Maps IonQ native gates to their OpenQASM 3 spellings.
+
+IonQ accepts these directly in OpenQASM 3.0 programs, without an include;
+their parameters are specified in turns, matching the plugin's operations.
+"""
+
+_GATESET_QASM3_GATES = {
+    "qis": OPENQASM_GATES,
+    "native": NATIVE_QASM3_GATES,
+}
+
+
+def _param_string(parameters, precision):
+    if precision is not None:
+        return ",".join(f"{p:.{precision}}" for p in parameters)
+    return ",".join(str(p) for p in parameters)
+
+
+# pylint: disable=unused-argument
+@singledispatch
+def _obj_string(
+    op: Operator, wires: Wires, bit_map: dict, precision: None | int, gates: dict
+) -> str:
+    try:
+        gate = gates[op.name]
+    except KeyError as e:
+        raise ValueError(f"Operation {op.name} not supported by the QASM 3 serializer") from e
+
+    if op.name == "GlobalPhase":
+        # QASM 3's gphase takes no qubit operands, and its convention
+        # (exp(i*gamma)) is opposite in sign to GlobalPhase (exp(-i*phi)).
+        return f"gphase({_param_string([-p for p in op.parameters], precision)});"
+
+    wire_labels = ",".join(f"q[{wires.index(w)}]" for w in op.wires.tolist())
+    params = f"({_param_string(op.parameters, precision)})" if op.num_params > 0 else ""
+
+    return f"{gate}{params} {wire_labels};"
+
+
+@_obj_string.register
+def _mid_measure_str(
+    op: MidMeasure, wires: Wires, bit_map: dict, precision: None | int, gates: dict
+) -> str:
+    if op.postselect is not None:
+        raise NotImplementedError(
+            f"Unable to translate mid circuit measurement with postselection {op}"
+        )
+
+    wire = f"q[{wires.index(op.wires[0])}]"
+    mcm_ind = len(bit_map)
+    bit_map[op] = mcm_ind
+    line = f"mcms[{mcm_ind}] = measure {wire};"
+
+    if op.reset:
+        # QASM 3 has an explicit reset statement; this is what enables qubit
+        # reuse, returning the measured qubit to |0> for later operations.
+        line += f"\nreset {wire};"
+
+    return line
+
+
+def _program_header(gateset: str) -> list[str]:
+    lines = ["OPENQASM 3.0;"]
+    if gateset != "native":
+        # IonQ native gates are accepted without an include; the abstract
+        # gates are the stdgates.inc spellings.
+        lines.append('include "stdgates.inc";')
+    return lines
+
+
+def _operations_qasm3_lines(operations, wires: Wires, precision: None | int, gates: dict):
+    """Serializes a list of operations to OpenQASM 3.0 statement lines,
+    decomposing operations without a QASM spelling into the target gate set."""
+    operations = [op for op in operations if op.name not in ("Barrier", "Snapshot")]
+    [transformed_tape], _ = convert_to_numpy_parameters(QuantumScript(operations))
+
+    def stopping_condition(op):
+        return op.name in gates or isinstance(op, MidMeasure)
+
+    [new_tape], _ = decompose(
+        transformed_tape,
+        target_gates=gates.keys() | {"MidMeasure"},
+        stopping_condition=stopping_condition,
+        skip_initial_state_prep=False,
+        name="to_qasm3",
+        error=ValueError,
+    )
+
+    bit_map = {}
+    return [_obj_string(op, wires, bit_map, precision, gates) for op in new_tape.operations]
+
+
+def operations_to_qasm3(operations, wires: WiresLike, gateset: str = "qis", precision=None) -> str:
+    """Serializes a list of operations to an OpenQASM 3.0 program without
+    terminal measurements.
+
+    This is the serializer behind the ``ionq.qasm3.v1`` device submission
+    path; terminal measurement handling is left to the backend.
+
+    Args:
+        operations (Iterable[Operation]): the operations to serialize, which
+            may include mid-circuit measurements and resets
+        wires (WiresLike): all device wires; wire labels are mapped to qubit
+            indices by their position
+        gateset (str): the target gateset, either ``"qis"`` (stdgates.inc
+            spellings) or ``"native"`` (IonQ native gates). Defaults to ``qis``.
+        precision (int or None): number of decimal digits to display for the
+            parameters
+
+    Returns:
+        str: OpenQASM 3.0 program corresponding to the operations
+    """
+    wires = Wires(wires)
+    operations = list(operations)
+    gates = _GATESET_QASM3_GATES[gateset]
+
+    lines = _program_header(gateset)
+    lines.append(f"qubit[{len(wires)}] q;")
+
+    num_mcms = sum(isinstance(op, MidMeasure) for op in operations)
+    if num_mcms:
+        lines.append(f"bit[{num_mcms}] mcms;")
+
+    lines += _operations_qasm3_lines(operations, wires, precision, gates)
+    return "\n".join(lines) + "\n"
+
+
+def _tape_qasm3(
+    tape: QuantumScript,
+    wires: Wires,
+    rotations: bool,
+    measure_all: bool,
+    precision: None | int,
+    gateset: str,
+) -> str:
+    """Helper function to serialize a tape as an OpenQASM 3.0 program."""
+    wires = wires or tape.wires
+    gates = _GATESET_QASM3_GATES[gateset]
+
+    lines = _program_header(gateset)
+
+    if tape.num_wires == 0:
+        # empty circuit
+        return "\n".join(lines) + "\n"
+
+    # create the quantum and classical registers
+    lines.append(f"qubit[{len(wires)}] q;")
+
+    terminally_measured_wires = (
+        wires
+        if measure_all
+        else Wires.all_wires([m.wires for m in tape.measurements if m.mv is None])
+    )
+    if terminally_measured_wires:
+        lines.append(f"bit[{len(terminally_measured_wires)}] c;")
+
+    num_mcms = sum(isinstance(o, MidMeasure) for o in tape.operations)
+    if num_mcms:
+        lines.append(f"bit[{num_mcms}] mcms;")
+
+    operations = list(tape.operations)
+    if rotations:
+        # if requested, append diagonalizing gates corresponding
+        # to circuit observables
+        operations += tape.diagonalizing_gates
+
+    lines += _operations_qasm3_lines(operations, wires, precision, gates)
+
+    # apply computational basis measurements to each quantum register
+    if measure_all:
+        for wire in range(len(wires)):
+            lines.append(f"c[{wire}] = measure q[{wire}];")
+    else:
+        for creg_indx, w in enumerate(terminally_measured_wires):
+            qreg_indx = tape.wires.index(w)
+            lines.append(f"c[{creg_indx}] = measure q[{qreg_indx}];")
+
+    return "\n".join(lines) + "\n"
+
+
+def to_qasm3(
+    circuit,
+    wires: WiresLike | None = None,
+    rotations: bool = True,
+    measure_all: bool = True,
+    precision: None | int = None,
+    gateset: str = "qis",
+):
+    """Convert a circuit to an OpenQASM 3.0 program.
+
+    Supports mid-circuit measurements, including measurements with
+    ``reset=True`` (qubit reuse). Terminal measurements are performed on all
+    qubits in the computational basis by default; restrict them to the wires
+    measured in the circuit with ``measure_all=False``.
+
+    Circuits with classically controlled operations (``qml.cond``) or
+    postselecting mid-circuit measurements are not supported and raise an
+    error.
+
+    Args:
+        circuit (QNode or QuantumScript): the quantum circuit to be serialized.
+        wires (Wires or None): the wires to use when serializing the circuit.
+            Default is ``None``, such that all the wires of the circuit are
+            used for serialization.
+        rotations (bool): if ``True``, add gates that rotate the quantum state
+            into the eigenbasis of the circuit's observables. Default is ``True``.
+        measure_all (bool): if ``True``, add a computational basis measurement
+            on all the qubits. Default is ``True``.
+        precision (int or None): number of decimal digits to display for the
+            parameters.
+        gateset (str): the target gateset, either ``"qis"`` (stdgates.inc
+            spellings) or ``"native"`` (IonQ native gates ``gpi``/``gpi2``/``ms``,
+            with parameters in turns). Defaults to ``qis``.
+
+    Returns:
+        str or callable: If a tape is provided, the OpenQASM 3.0 program is
+        returned directly. If a QNode is provided, a wrapper is returned that
+        accepts the QNode's arguments and returns the program.
+
+    **Example**
+
+    .. code-block:: python
+
+        dev = qml.device("ionq.simulator", wires=2, shots=1024)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(0)
+            qml.measure(0, reset=True)
+            qml.CNOT(wires=[0, 1])
+            return qml.sample()
+
+    >>> print(to_qasm3(circuit)())
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    bit[2] c;
+    bit[1] mcms;
+    h q[0];
+    mcms[0] = measure q[0];
+    reset q[0];
+    cx q[0],q[1];
+    c[0] = measure q[0];
+    c[1] = measure q[1];
+    """
+    if isinstance(circuit, QuantumScript):
+        return _tape_qasm3(
+            circuit,
+            wires=wires,
+            rotations=rotations,
+            measure_all=measure_all,
+            precision=precision,
+            gateset=gateset,
+        )
+
+    @wraps(circuit)
+    def wrapper(*args, **kwargs) -> str:
+        tape = construct_tape(circuit)(*args, **kwargs)
+        return _tape_qasm3(
+            tape,
+            wires=wires,
+            rotations=rotations,
+            measure_all=measure_all,
+            precision=precision,
+            gateset=gateset,
+        )
+
+    return wrapper

--- a/pennylane_ionq/qasm3.py
+++ b/pennylane_ionq/qasm3.py
@@ -85,7 +85,9 @@ def _gate_string(op, wires: Wires, precision: None | int, gates: dict) -> str:
     try:
         gate = gates[op.name]
     except KeyError as e:
-        raise ValueError(f"Operation {op.name} not supported by the PennyLane-IonQ QASM 3 serializer") from e
+        raise ValueError(
+            f"Operation {op.name} not supported by the PennyLane-IonQ QASM 3 serializer"
+        ) from e
 
     if op.name == "GlobalPhase":
         # QASM 3's gphase takes no qubit operands, and its convention

--- a/pennylane_ionq/qasm3.py
+++ b/pennylane_ionq/qasm3.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2026 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ def _gate_string(op, wires: Wires, precision: None | int, gates: dict) -> str:
         # (exp(i*gamma)) is opposite in sign to GlobalPhase (exp(-i*phi)).
         return f"gphase({_param_string([-p for p in op.parameters], precision)});"
 
-    wire_labels = ",".join(f"q[{wires.index(w)}]" for w in op.wires.tolist())
+    wire_labels = ", ".join(f"q[{wires.index(w)}]" for w in op.wires.tolist())
     params = f"({_param_string(op.parameters, precision)})" if op.num_params > 0 else ""
 
     return f"{gate}{params} {wire_labels};"
@@ -164,7 +164,7 @@ def operations_to_qasm3(operations, wires: WiresLike, gateset: str = "qis", prec
     h q[0];
     mcms[0] = measure q[0];
     reset q[0];
-    cx q[0],q[1];
+    cx q[0], q[1];
     """
     wires = Wires(wires)
     gates = _GATESET_QASM3_GATES[gateset]

--- a/pennylane_ionq/qasm3.py
+++ b/pennylane_ionq/qasm3.py
@@ -25,7 +25,7 @@ Changes from the original:
   instead of raising ``NotImplementedError``.
 - Supports the IonQ native gateset (``gpi``/``gpi2``/``ms``), whose gates
   IonQ accepts directly in OpenQASM 3.0 programs with parameters in turns.
-- Classically controlled operations (``qml.cond``) are intentionally not
+- Classically controlled operations (``qp.cond``) are intentionally not
   supported; this exporter is scoped to mid-circuit measurement and qubit
   reuse only. Circuits containing a ``Conditional`` raise ``ValueError``.
 """
@@ -274,7 +274,7 @@ def to_qasm3(
     qubits in the computational basis by default; restrict them to the wires
     measured in the circuit with ``measure_all=False``.
 
-    Circuits with classically controlled operations (``qml.cond``) or
+    Circuits with classically controlled operations (``qp.cond``) or
     postselecting mid-circuit measurements are not supported and raise an
     error.
 
@@ -302,14 +302,14 @@ def to_qasm3(
 
     .. code-block:: python
 
-        dev = qml.device("ionq.simulator", wires=2, shots=1024)
+        dev = qp.device("ionq.simulator", wires=2, shots=1024)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.Hadamard(0)
-            qml.measure(0, reset=True)
-            qml.CNOT(wires=[0, 1])
-            return qml.sample()
+            qp.Hadamard(0)
+            qp.measure(0, reset=True)
+            qp.CNOT(wires=[0, 1])
+            return qp.sample()
 
     >>> print(to_qasm3(circuit)())
     OPENQASM 3.0;

--- a/pennylane_ionq/qasm3.py
+++ b/pennylane_ionq/qasm3.py
@@ -12,33 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Conversion of a circuit to an OpenQASM 3.0 program.
+Serialization of PennyLane operations to OpenQASM 3.0 programs for
+``ionq.qasm3.v1`` jobs, supporting mid-circuit measurements and qubit reuse.
 
-Adapted from ``pennylane.io.to_openqasm`` (PennyLane, Apache License 2.0):
-https://github.com/PennyLaneAI/pennylane/blob/master/pennylane/io/to_openqasm.py
-
-Changes from the original:
-
-- Emits OpenQASM 3.0 syntax instead of OpenQASM 2.0 (``qubit[]``/``bit[]``
-  declarations, assignment-form measurement, explicit ``reset``).
-- Mid-circuit measurements with ``reset=True`` are supported (qubit reuse)
-  instead of raising ``NotImplementedError``.
-- Supports the IonQ native gateset (``gpi``/``gpi2``/``ms``), whose gates
-  IonQ accepts directly in OpenQASM 3.0 programs with parameters in turns.
-- Classically controlled operations (``qp.cond``) are intentionally not
-  supported; this exporter is scoped to mid-circuit measurement and qubit
-  reuse only. Circuits containing a ``Conditional`` raise ``ValueError``.
+Adapted from ``pennylane.io.to_openqasm`` (PennyLane, Apache License 2.0).
 """
 
-from functools import singledispatch, wraps
-
 from pennylane.devices.preprocess import decompose
-from pennylane.operation import Operator
 from pennylane.ops import MidMeasure
 from pennylane.tape import QuantumScript
 from pennylane.transforms import convert_to_numpy_parameters
 from pennylane.wires import Wires, WiresLike
-from pennylane.workflow import construct_tape
 
 OPENQASM_GATES = {
     "CNOT": "cx",
@@ -97,15 +81,11 @@ def _param_string(parameters, precision):
     return ",".join(str(p) for p in parameters)
 
 
-# pylint: disable=unused-argument
-@singledispatch
-def _obj_string(
-    op: Operator, wires: Wires, bit_map: dict, precision: None | int, gates: dict
-) -> str:
+def _gate_string(op, wires: Wires, precision: None | int, gates: dict) -> str:
     try:
         gate = gates[op.name]
     except KeyError as e:
-        raise ValueError(f"Operation {op.name} not supported by the QASM 3 serializer") from e
+        raise ValueError(f"Operation {op.name} not supported by the PennyLane-IonQ QASM 3 serializer") from e
 
     if op.name == "GlobalPhase":
         # QASM 3's gphase takes no qubit operands, and its convention
@@ -118,19 +98,14 @@ def _obj_string(
     return f"{gate}{params} {wire_labels};"
 
 
-@_obj_string.register
-def _mid_measure_str(
-    op: MidMeasure, wires: Wires, bit_map: dict, precision: None | int, gates: dict
-) -> str:
+def _mid_measure_string(op: MidMeasure, wires: Wires, mcm_index: int) -> str:
     if op.postselect is not None:
         raise NotImplementedError(
             f"Unable to translate mid circuit measurement with postselection {op}"
         )
 
     wire = f"q[{wires.index(op.wires[0])}]"
-    mcm_ind = len(bit_map)
-    bit_map[op] = mcm_ind
-    line = f"mcms[{mcm_ind}] = measure {wire};"
+    line = f"mcms[{mcm_index}] = measure {wire};"
 
     if op.reset:
         # QASM 3 has an explicit reset statement; this is what enables qubit
@@ -140,43 +115,13 @@ def _mid_measure_str(
     return line
 
 
-def _program_header(gateset: str) -> list[str]:
-    lines = ["OPENQASM 3.0;"]
-    if gateset != "native":
-        # IonQ native gates are accepted without an include; the abstract
-        # gates are the stdgates.inc spellings.
-        lines.append('include "stdgates.inc";')
-    return lines
-
-
-def _operations_qasm3_lines(operations, wires: Wires, precision: None | int, gates: dict):
-    """Serializes a list of operations to OpenQASM 3.0 statement lines,
-    decomposing operations without a QASM spelling into the target gate set."""
-    operations = [op for op in operations if op.name not in ("Barrier", "Snapshot")]
-    [transformed_tape], _ = convert_to_numpy_parameters(QuantumScript(operations))
-
-    def stopping_condition(op):
-        return op.name in gates or isinstance(op, MidMeasure)
-
-    [new_tape], _ = decompose(
-        transformed_tape,
-        target_gates=gates.keys() | {"MidMeasure"},
-        stopping_condition=stopping_condition,
-        skip_initial_state_prep=False,
-        name="to_qasm3",
-        error=ValueError,
-    )
-
-    bit_map = {}
-    return [_obj_string(op, wires, bit_map, precision, gates) for op in new_tape.operations]
-
-
 def operations_to_qasm3(operations, wires: WiresLike, gateset: str = "qis", precision=None) -> str:
     """Serializes a list of operations to an OpenQASM 3.0 program without
     terminal measurements.
 
     This is the serializer behind the ``ionq.qasm3.v1`` device submission
-    path; terminal measurement handling is left to the backend.
+    path; terminal measurement handling is left to the backend. Operations
+    without a QASM spelling are decomposed into the target gateset.
 
     Args:
         operations (Iterable[Operation]): the operations to serialize, which
@@ -190,160 +135,70 @@ def operations_to_qasm3(operations, wires: WiresLike, gateset: str = "qis", prec
 
     Returns:
         str: OpenQASM 3.0 program corresponding to the operations
-    """
-    wires = Wires(wires)
-    operations = list(operations)
-    gates = _GATESET_QASM3_GATES[gateset]
 
-    lines = _program_header(gateset)
-    lines.append(f"qubit[{len(wires)}] q;")
-
-    num_mcms = sum(isinstance(op, MidMeasure) for op in operations)
-    if num_mcms:
-        lines.append(f"bit[{num_mcms}] mcms;")
-
-    lines += _operations_qasm3_lines(operations, wires, precision, gates)
-    return "\n".join(lines) + "\n"
-
-
-def _tape_qasm3(
-    tape: QuantumScript,
-    wires: Wires,
-    rotations: bool,
-    measure_all: bool,
-    precision: None | int,
-    gateset: str,
-) -> str:
-    """Helper function to serialize a tape as an OpenQASM 3.0 program."""
-    wires = wires or tape.wires
-    gates = _GATESET_QASM3_GATES[gateset]
-
-    lines = _program_header(gateset)
-
-    if tape.num_wires == 0:
-        # empty circuit
-        return "\n".join(lines) + "\n"
-
-    # create the quantum and classical registers
-    lines.append(f"qubit[{len(wires)}] q;")
-
-    terminally_measured_wires = (
-        wires
-        if measure_all
-        else Wires.all_wires([m.wires for m in tape.measurements if m.mv is None])
-    )
-    if terminally_measured_wires:
-        lines.append(f"bit[{len(terminally_measured_wires)}] c;")
-
-    num_mcms = sum(isinstance(o, MidMeasure) for o in tape.operations)
-    if num_mcms:
-        lines.append(f"bit[{num_mcms}] mcms;")
-
-    operations = list(tape.operations)
-    if rotations:
-        # if requested, append diagonalizing gates corresponding
-        # to circuit observables
-        operations += tape.diagonalizing_gates
-
-    lines += _operations_qasm3_lines(operations, wires, precision, gates)
-
-    # apply computational basis measurements to each quantum register
-    if measure_all:
-        for wire in range(len(wires)):
-            lines.append(f"c[{wire}] = measure q[{wire}];")
-    else:
-        for creg_indx, w in enumerate(terminally_measured_wires):
-            qreg_indx = tape.wires.index(w)
-            lines.append(f"c[{creg_indx}] = measure q[{qreg_indx}];")
-
-    return "\n".join(lines) + "\n"
-
-
-def to_qasm3(
-    circuit,
-    wires: WiresLike | None = None,
-    rotations: bool = True,
-    measure_all: bool = True,
-    precision: None | int = None,
-    gateset: str = "qis",
-):
-    """Convert a circuit to an OpenQASM 3.0 program.
-
-    Supports mid-circuit measurements, including measurements with
-    ``reset=True`` (qubit reuse). Terminal measurements are performed on all
-    qubits in the computational basis by default; restrict them to the wires
-    measured in the circuit with ``measure_all=False``.
-
-    Circuits with classically controlled operations (``qp.cond``) or
-    postselecting mid-circuit measurements are not supported and raise an
-    error.
-
-    Args:
-        circuit (QNode or QuantumScript): the quantum circuit to be serialized.
-        wires (Wires or None): the wires to use when serializing the circuit.
-            Default is ``None``, such that all the wires of the circuit are
-            used for serialization.
-        rotations (bool): if ``True``, add gates that rotate the quantum state
-            into the eigenbasis of the circuit's observables. Default is ``True``.
-        measure_all (bool): if ``True``, add a computational basis measurement
-            on all the qubits. Default is ``True``.
-        precision (int or None): number of decimal digits to display for the
-            parameters.
-        gateset (str): the target gateset, either ``"qis"`` (stdgates.inc
-            spellings) or ``"native"`` (IonQ native gates ``gpi``/``gpi2``/``ms``,
-            with parameters in turns). Defaults to ``qis``.
-
-    Returns:
-        str or callable: If a tape is provided, the OpenQASM 3.0 program is
-        returned directly. If a QNode is provided, a wrapper is returned that
-        accepts the QNode's arguments and returns the program.
+    Raises:
+        ValueError: if the operations contain a classically controlled
+            operation (``qp.cond``), or an operation that cannot be
+            decomposed into the target gateset
+        NotImplementedError: if the operations contain a mid-circuit
+            measurement with postselection
 
     **Example**
 
     .. code-block:: python
 
-        dev = qp.device("ionq.simulator", wires=2, shots=1024)
-
-        @qp.qnode(dev)
-        def circuit():
+        with qp.queuing.AnnotatedQueue() as q:
             qp.Hadamard(0)
             qp.measure(0, reset=True)
             qp.CNOT(wires=[0, 1])
-            return qp.sample()
 
-    >>> print(to_qasm3(circuit)())
+        tape = qp.tape.QuantumScript.from_queue(q)
+
+    >>> print(operations_to_qasm3(tape.operations, wires=[0, 1]))
     OPENQASM 3.0;
     include "stdgates.inc";
     qubit[2] q;
-    bit[2] c;
     bit[1] mcms;
     h q[0];
     mcms[0] = measure q[0];
     reset q[0];
     cx q[0],q[1];
-    c[0] = measure q[0];
-    c[1] = measure q[1];
     """
-    if isinstance(circuit, QuantumScript):
-        return _tape_qasm3(
-            circuit,
-            wires=wires,
-            rotations=rotations,
-            measure_all=measure_all,
-            precision=precision,
-            gateset=gateset,
-        )
+    wires = Wires(wires)
+    gates = _GATESET_QASM3_GATES[gateset]
 
-    @wraps(circuit)
-    def wrapper(*args, **kwargs) -> str:
-        tape = construct_tape(circuit)(*args, **kwargs)
-        return _tape_qasm3(
-            tape,
-            wires=wires,
-            rotations=rotations,
-            measure_all=measure_all,
-            precision=precision,
-            gateset=gateset,
-        )
+    operations = [op for op in operations if op.name not in ("Barrier", "Snapshot")]
+    [tape], _ = convert_to_numpy_parameters(QuantumScript(operations))
 
-    return wrapper
+    def stopping_condition(op):
+        return op.name in gates or isinstance(op, MidMeasure)
+
+    [tape], _ = decompose(
+        tape,
+        target_gates=gates.keys() | {"MidMeasure"},
+        stopping_condition=stopping_condition,
+        skip_initial_state_prep=False,
+        name="operations_to_qasm3",
+        error=ValueError,
+    )
+
+    lines = ["OPENQASM 3.0;"]
+    if gateset != "native":
+        # IonQ native gates are accepted without an include;
+        # for other gatesets use stdgates.inc defs.
+        lines.append('include "stdgates.inc";')
+    lines.append(f"qubit[{len(wires)}] q;")
+
+    num_mcms = sum(isinstance(op, MidMeasure) for op in tape.operations)
+    if num_mcms:
+        lines.append(f"bit[{num_mcms}] mcms;")
+
+    mcm_index = 0
+    for op in tape.operations:
+        if isinstance(op, MidMeasure):
+            lines.append(_mid_measure_string(op, wires, mcm_index))
+            mcm_index += 1
+        else:
+            lines.append(_gate_string(op, wires, precision, gates))
+
+    return "\n".join(lines) + "\n"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -548,12 +548,8 @@ class TestDeviceIntegration:
         assert dev.tracker.history["batches"] == [1]
         assert dev.tracker.history["batch_len"] == [2]
         assert len(dev.tracker.history["resources"]) == 2
-        resources = dev.tracker.history["resources"][0]
-        assert resources.num_allocs == 1
-        assert resources.total_quantum_operations == 1
-        assert resources.depth == 1
-        assert resources.quantum_operations == {"GPI": 1}
-        assert resources.measurement_processes == {"probs(all wires)": 1}
+        assert dev.tracker.history["resources"][0] == tape1.specs["resources"]
+        assert dev.tracker.history["resources"][1] == tape1.specs["resources"]
         assert len(dev.tracker.history["results"]) == 2
 
     def test_not_recording_when_pennylane_tracker_not_active(self, requires_api):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1214,8 +1214,9 @@ def _mcm_tape():
 
 
 class TestMidCircuitMeasurement:
-    """Tests for routing mid-circuit measurement, reset, and classical control
-    flow through the ionq.qasm3.v1 submission path.
+    """Tests for routing mid-circuit measurement and reset through the
+    ionq.qasm3.v1 submission path. Classically controlled operations
+    (qml.cond) are rejected with a clear error.
 
     These tests mirror the ones added to qiskit-ionq in "feat: mid-circuit
     measurement via ionq.qasm3.v1" (qiskit-ionq #258) and are written
@@ -1234,13 +1235,14 @@ class TestMidCircuitMeasurement:
             qml.PauliX(0)
         assert _requires_qasm3(tape) is True
 
-    def test_requires_qasm3_cond(self):
-        """Classically controlled operations (qml.cond) require the qasm3 path."""
+    def test_cond_raises(self):
+        """Classically controlled operations (qml.cond) are not supported."""
         with qml.tape.QuantumTape() as tape:
             qml.Hadamard(0)
             m = qml.measure(0)
             qml.cond(m, qml.PauliX)(0)
-        assert _requires_qasm3(tape) is True
+        with pytest.raises(ValueError, match="qml.cond.*not supported"):
+            _requires_qasm3(tape)
 
     @pytest.mark.parametrize(
         "measurement",
@@ -1260,13 +1262,14 @@ class TestMidCircuitMeasurement:
             measurement()
         assert _requires_qasm3(tape) is False
 
-    def test_requires_qasm3_cond_else(self):
-        """A conditional with both true and false branches requires the qasm3 path."""
+    def test_cond_else_raises(self):
+        """A conditional with both true and false branches is not supported."""
         with qml.tape.QuantumTape() as tape:
             qml.Hadamard(0)
             m = qml.measure(0)
             qml.cond(m, qml.PauliX, qml.PauliZ)(0)
-        assert _requires_qasm3(tape) is True
+        with pytest.raises(ValueError, match="qml.cond.*not supported"):
+            _requires_qasm3(tape)
 
     def test_requires_qasm3_reuse(self):
         """A gate after a mid-circuit measurement (qubit reuse) requires the qasm3 path."""
@@ -1306,8 +1309,41 @@ class TestMidCircuitMeasurement:
         dev.apply(_mcm_tape().operations)
 
         assert dev.job["type"] == "ionq.qasm3.v1"
-        assert dev.job["settings"]["compilation"] == {"opt": 0}
+        assert dev.job["settings"]["compilation"] == {"opt": 0, "service_version": "v0.4"}
         assert dev.job["settings"]["error_mitigation"] == {"debiasing": False}
+
+    def test_qasm3_service_version(self, monkeypatch):
+        """qasm3 jobs pin compilation.service_version v0.4; a caller can override."""
+        monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
+
+        dev = IonQDevice(wires=(0,), shots=1024)
+        dev.apply(_mcm_tape().operations)
+        assert dev.job["settings"]["compilation"]["service_version"] == "v0.4"
+
+        dev = IonQDevice(wires=(0,), shots=1024, compilation={"service_version": "v0.5"})
+        dev.apply(_mcm_tape().operations)
+        assert dev.job["settings"]["compilation"]["service_version"] == "v0.5"
+
+    def test_qasm3_native_gateset(self, monkeypatch):
+        """MCM circuits in the native gateset serialize with native gate
+        spellings and without stdgates.inc."""
+        monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
+        dev = IonQDevice(wires=2, shots=1024, gateset="native")
+
+        with qml.tape.QuantumTape() as tape:
+            GPI(0.5, wires=[0])
+            qml.measure(0, reset=True)
+            MS(0, 0.5, wires=[0, 1])
+            qml.probs(wires=[0, 1])
+
+        dev.apply(tape.operations)
+
+        assert dev.job["type"] == "ionq.qasm3.v1"
+        data = dev.job["input"]["data"]
+        assert "stdgates.inc" not in data
+        assert "gpi(0.5) q[0];" in data
+        assert "reset q[0];" in data
+        assert "ms(0,0.5,0.25) q[0],q[1];" in data
 
     def test_multi_circuit_mcm_raises(self, monkeypatch):
         """Multi-circuit MCM submissions are rejected with a clear error."""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -28,6 +28,7 @@ from pennylane_ionq.device import (
     IonQDevice,
     SimulatorDevice,
     CircuitIndexNotSetException,
+    circuit_requires_qasm3,
 )
 from pennylane_ionq.ops import GPI, GPI2, MS, XX, YY, ZZ
 from pennylane.measurements import SampleMeasurement, ShotCopies
@@ -1212,14 +1213,6 @@ class TestJobAttribute:
         assert gate["rotation"] == rotation
 
 
-def _requires_qasm3(tape):
-    """Deferred import so that collecting this module does not fail while the
-    TDD target ``circuit_requires_qasm3`` is not implemented yet."""
-    from pennylane_ionq.device import circuit_requires_qasm3
-
-    return circuit_requires_qasm3(tape)
-
-
 def _mcm_tape():
     """1-qubit mid-circuit-measurement tape (the API schema example)."""
     with qp.tape.QuantumTape(shots=1024) as tape:
@@ -1240,7 +1233,7 @@ class TestMidCircuitMeasurement:
 
     def test_requires_qasm3_mcm(self):
         """Reusing a qubit after a mid-circuit measurement requires the qasm3 path."""
-        assert _requires_qasm3(_mcm_tape()) is True
+        assert circuit_requires_qasm3(_mcm_tape()) is True
 
     def test_requires_qasm3_reset(self):
         """A mid-circuit measurement with reset requires the qasm3 path."""
@@ -1248,7 +1241,7 @@ class TestMidCircuitMeasurement:
             qp.Hadamard(0)
             qp.measure(0, reset=True)
             qp.PauliX(0)
-        assert _requires_qasm3(tape) is True
+        assert circuit_requires_qasm3(tape) is True
 
     def test_cond_raises(self):
         """Classically controlled operations (qp.cond) are not supported."""
@@ -1257,7 +1250,7 @@ class TestMidCircuitMeasurement:
             m = qp.measure(0)
             qp.cond(m, qp.PauliX)(0)
         with pytest.raises(ValueError, match="qp.cond.*not supported"):
-            _requires_qasm3(tape)
+            circuit_requires_qasm3(tape)
 
     @pytest.mark.parametrize(
         "measurement",
@@ -1275,7 +1268,7 @@ class TestMidCircuitMeasurement:
             qp.Hadamard(0)
             qp.CNOT(wires=[0, 1])
             measurement()
-        assert _requires_qasm3(tape) is False
+        assert circuit_requires_qasm3(tape) is False
 
     def test_cond_else_raises(self):
         """A conditional with both true and false branches is not supported."""
@@ -1284,7 +1277,7 @@ class TestMidCircuitMeasurement:
             m = qp.measure(0)
             qp.cond(m, qp.PauliX, qp.PauliZ)(0)
         with pytest.raises(ValueError, match="qp.cond.*not supported"):
-            _requires_qasm3(tape)
+            circuit_requires_qasm3(tape)
 
     def test_requires_qasm3_reuse(self):
         """A gate after a mid-circuit measurement (qubit reuse) requires the qasm3 path."""
@@ -1292,7 +1285,7 @@ class TestMidCircuitMeasurement:
             qp.Hadamard(0)
             qp.measure(0)
             qp.PauliX(0)
-        assert _requires_qasm3(tape) is True
+        assert circuit_requires_qasm3(tape) is True
 
     def test_qasm3_payload_shape(self, monkeypatch):
         """MCM tapes serialize to an ionq.qasm3.v1 payload with QASM 3 input."""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -16,7 +16,6 @@
 import json
 import logging
 import numpy as np
-import pennylane as qml
 import pennylane as qp
 import pytest
 import requests
@@ -87,7 +86,7 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize("d", shortnames)
     def test_load_device(self, d):
         """Test that the device loads correctly"""
-        dev = qml.device(d, wires=2)
+        dev = qp.device(d, wires=2)
         assert dev.num_wires == 2
         assert dev.shots.total_shots is None
         assert dev.short_name == d
@@ -96,17 +95,17 @@ class TestDeviceIntegration:
     def test_args(self, d):
         """Test that the device requires correct arguments"""
         with pytest.raises(TypeError, match="missing 1 required positional argument"):
-            qml.device(d)
+            qp.device(d)
 
         # IonQ devices allow shots=None
-        dev = qml.device(d, wires=1)
+        dev = qp.device(d, wires=1)
 
         # But the execution will raise error
-        @qml.qnode(dev, shots=None)
+        @qp.qnode(dev, shots=None)
         def circuit():
             """Reference QNode"""
-            qml.PauliX(wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.PauliX(wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         with pytest.raises(ValueError, match="does not support analytic"):
             circuit()
@@ -154,13 +153,13 @@ class TestDeviceIntegration:
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device("ionq.simulator", wires=1, api_key="test")
+        dev = qp.device("ionq.simulator", wires=1, api_key="test")
 
-        @qml.qnode(dev, shots=shots)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             """Reference QNode"""
-            qml.PauliX(wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.PauliX(wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         spy = mocker.spy(requests, "post")
         circuit()
@@ -182,13 +181,13 @@ class TestDeviceIntegration:
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device("ionq.simulator", wires=1, dry_run=True, api_key="test")
+        dev = qp.device("ionq.simulator", wires=1, dry_run=True, api_key="test")
 
-        @qml.qnode(dev, shots=1024)
+        @qp.qnode(dev, shots=1024)
         def circuit():
             """Reference QNode"""
-            qml.Identity(wires=0)
-            return qml.probs(wires=[0])
+            qp.Identity(wires=0)
+            return qp.probs(wires=[0])
 
         spy = mocker.spy(requests, "post")
         circuit()
@@ -198,12 +197,12 @@ class TestDeviceIntegration:
     def test_dry_run_execute(self, requires_api):
         """Send a job with dry_run option set to true to the API."""
 
-        dev = qml.device("ionq.simulator", wires=1, dry_run=True)
+        dev = qp.device("ionq.simulator", wires=1, dry_run=True)
 
-        @qml.qnode(dev, shots=1024)
+        @qp.qnode(dev, shots=1024)
         def circuit():
-            qml.Identity(wires=0)
-            return qml.probs(wires=[0])
+            qp.Identity(wires=0)
+            return qp.probs(wires=[0])
 
         res = circuit()
         assert res == []
@@ -224,7 +223,7 @@ class TestDeviceIntegration:
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device(
+        dev = qp.device(
             "ionq.simulator",
             wires=1,
             noise_model="ideal",
@@ -232,11 +231,11 @@ class TestDeviceIntegration:
             api_key="test",
         )
 
-        @qml.qnode(dev, shots=1024)
+        @qp.qnode(dev, shots=1024)
         def circuit():
             """Reference QNode"""
-            qml.Identity(wires=0)
-            return qml.probs(wires=[0])
+            qp.Identity(wires=0)
+            return qp.probs(wires=[0])
 
         spy = mocker.spy(requests, "post")
         circuit()
@@ -262,18 +261,18 @@ class TestDeviceIntegration:
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device(
+        dev = qp.device(
             "ionq.simulator",
             wires=1,
             metadata={"key": "value"},
             api_key="test",
         )
 
-        @qml.qnode(dev, shots=1024)
+        @qp.qnode(dev, shots=1024)
         def circuit():
             """Reference QNode"""
-            qml.Identity(wires=0)
-            return qml.probs(wires=[0])
+            qp.Identity(wires=0)
+            return qp.probs(wires=[0])
 
         spy = mocker.spy(requests, "post")
         circuit()
@@ -296,13 +295,13 @@ class TestDeviceIntegration:
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device("ionq.simulator", wires=1, job_name="test_name", api_key="test")
+        dev = qp.device("ionq.simulator", wires=1, job_name="test_name", api_key="test")
 
-        @qml.qnode(dev, shots=1024)
+        @qp.qnode(dev, shots=1024)
         def circuit():
             """Reference QNode"""
-            qml.Identity(wires=0)
-            return qml.probs(wires=[0])
+            qp.Identity(wires=0)
+            return qp.probs(wires=[0])
 
         spy = mocker.spy(requests, "post")
         circuit()
@@ -326,18 +325,18 @@ class TestDeviceIntegration:
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device(
+        dev = qp.device(
             "ionq.qpu",
             wires=1,
             api_key="test",
             compilation=compilation,
         )
 
-        @qml.qnode(dev, shots=5000)
+        @qp.qnode(dev, shots=5000)
         def circuit():
             """Reference QNode"""
-            qml.PauliX(wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.PauliX(wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         spy = mocker.spy(requests, "post")
         circuit()
@@ -365,18 +364,18 @@ class TestDeviceIntegration:
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device(
+        dev = qp.device(
             "ionq.qpu",
             wires=1,
             api_key="test",
             error_mitigation=error_mitigation,
         )
 
-        @qml.qnode(dev, shots=5000)
+        @qp.qnode(dev, shots=5000)
         def circuit():
             """Reference QNode"""
-            qml.PauliX(wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.PauliX(wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         spy = mocker.spy(requests, "post")
         circuit()
@@ -416,7 +415,7 @@ class TestDeviceIntegration:
 
         monkeypatch.setattr(ResourceManager, "get", fake_response)
 
-        dev = qml.device(
+        dev = qp.device(
             "ionq.simulator",
             wires=1,
             api_key="test",
@@ -424,12 +423,12 @@ class TestDeviceIntegration:
             noise_seed=noise_seed,
         )
 
-        @qml.set_shots(5000)
-        @qml.qnode(dev)
+        @qp.set_shots(5000)
+        @qp.qnode(dev)
         def circuit():
             """Reference QNode"""
-            qml.PauliX(wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.PauliX(wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         spy = mocker.spy(requests, "post")
         circuit()
@@ -447,62 +446,62 @@ class TestDeviceIntegration:
     def test_noise_model_invalid(self):
         """Test that an invalid noise model raises ValueError."""
         with pytest.raises(ValueError, match="Invalid noise model"):
-            qml.device("ionq.simulator", wires=1, api_key="test", noise_model="invalid")
+            qp.device("ionq.simulator", wires=1, api_key="test", noise_model="invalid")
 
     def test_noise_seed_invalid(self):
         """Test that an invalid noise seed raises ValueError."""
         with pytest.raises(ValueError, match="noise_seed must be an integer"):
-            qml.device(
+            qp.device(
                 "ionq.simulator", wires=1, api_key="test", noise_model="aria-1", noise_seed=0
             )
         with pytest.raises(ValueError, match="noise_seed must be an integer"):
-            qml.device(
+            qp.device(
                 "ionq.simulator", wires=1, api_key="test", noise_model="aria-1", noise_seed=-1
             )
         with pytest.raises(ValueError, match="noise_seed must be an integer"):
-            qml.device(
+            qp.device(
                 "ionq.simulator", wires=1, api_key="test", noise_model="aria-1", noise_seed=2**31
             )
         with pytest.raises(ValueError, match="noise_seed must be an integer"):
-            qml.device(
+            qp.device(
                 "ionq.simulator", wires=1, api_key="test", noise_model="aria-1", noise_seed=True
             )
 
     def test_noise_seed_without_model(self):
         """Test that noise_seed without noise_model raises ValueError."""
         with pytest.raises(ValueError, match="noise_seed requires noise_model"):
-            qml.device("ionq.simulator", wires=1, api_key="test", noise_seed=42)
+            qp.device("ionq.simulator", wires=1, api_key="test", noise_seed=42)
 
     @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_circuit(self, shots, requires_api, tol):
         """Test that devices provide correct result for a simple circuit"""
-        dev = qml.device("ionq.simulator", wires=1)
+        dev = qp.device("ionq.simulator", wires=1)
 
         a = 0.543
         b = 0.123
-        c = qml.numpy.array(0.987, requires_grad=False)
+        c = qp.numpy.array(0.987, requires_grad=False)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(x, y, z):
             """Reference QNode"""
-            qml.BasisState(np.array([1]), wires=0)
-            qml.Hadamard(wires=0)
-            qml.Rot(x, y, z, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.BasisState(np.array([1]), wires=0)
+            qp.Hadamard(wires=0)
+            qp.Rot(x, y, z, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         assert np.allclose(circuit(a, b, c), np.cos(a) * np.sin(b), **tol)
 
     @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_ordering(self, shots, requires_api, tol):
         """Test that probabilities are returned with the correct qubit ordering"""
-        dev = qml.device("ionq.simulator", wires=2)
+        dev = qp.device("ionq.simulator", wires=2)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit():
-            qml.PauliX(wires=1)
-            return qml.probs(wires=[0, 1])
+            qp.PauliX(wires=1)
+            return qp.probs(wires=[0, 1])
 
         res = circuit()
         assert np.allclose(res, np.array([0.0, 1.0, 0.0, 0.0]), **tol)
@@ -511,7 +510,7 @@ class TestDeviceIntegration:
     def test_prob_no_results(self, d):
         """Test that the prob attribute is
         None if no job has yet been run."""
-        dev = qml.device(d, wires=1)
+        dev = qp.device(d, wires=1)
         assert dev.prob is None
 
     @pytest.mark.parametrize(
@@ -527,7 +526,7 @@ class TestDeviceIntegration:
     )
     def test_backend_initialization(self, backend):
         """Test that the device initializes with the correct backend."""
-        dev = qml.device(
+        dev = qp.device(
             "ionq.qpu",
             wires=2,
             backend=backend,
@@ -537,12 +536,12 @@ class TestDeviceIntegration:
     def test_recording_when_pennylane_tracker_active(self, requires_api):
         """Test recording device execution history via pennnylane tracker class."""
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
-        dev.tracker = qml.Tracker()
+        dev.tracker = qp.Tracker()
         dev.tracker.active = True
         dev.tracker.reset()
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0, wires=[0])
-            qml.probs(wires=[0])
+            qp.probs(wires=[0])
         dev.batch_execute([tape1, tape1])
         assert dev.tracker.history["executions"] == [1, 1]
         assert dev.tracker.history["shots"] == [1024, 1024]
@@ -560,20 +559,20 @@ class TestDeviceIntegration:
     def test_not_recording_when_pennylane_tracker_not_active(self, requires_api):
         """Test recording device not executed when tracker is inactive."""
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
-        dev.tracker = qml.Tracker()
+        dev.tracker = qp.Tracker()
         dev.tracker.active = False
         dev.tracker.reset()
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0, wires=[0])
-            qml.probs(wires=[0])
+            qp.probs(wires=[0])
         dev.batch_execute([tape1])
         assert dev.tracker.history == {}
 
     def test_warning_on_empty_circuit(self, requires_api):
         """Test warning are shown when circuit is empty."""
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
-            qml.probs(wires=[0])
+        with qp.tape.QuantumTape(shots=1024) as tape1:
+            qp.probs(wires=[0])
         with pytest.warns(
             UserWarning,
             match="Circuit is empty. Empty circuits return failures. Submitting anyway.",
@@ -590,9 +589,9 @@ class TestDeviceIntegration:
     ):
         """Test logging invoked in batch_execute method."""
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0, wires=[0])
-            qml.probs(wires=[0])
+            qp.probs(wires=[0])
         dev.batch_execute([tape1])
         assert mock_logging_is_enabled_for_method.called
         assert mock_logging_is_enabled_for_method.call_args[0][0] == logging.DEBUG
@@ -603,9 +602,9 @@ class TestDeviceIntegration:
         previously set when multiple circuits are submitted in one job.
         """
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0.5, wires=[0])
-            qml.probs(wires=[0])
+            qp.probs(wires=[0])
         dev.batch_execute([tape1, tape1])
         with pytest.raises(
             CircuitIndexNotSetException,
@@ -617,16 +616,16 @@ you want to access must be first set via the set_current_circuit_index device me
     def test_batch_execute_probabilities(self, requires_api):
         """Test batch_execute method when computing circuit probabilities."""
         dev = SimulatorDevice(wires=(0, 1, 2), gateset="native", shots=1024)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0.5, wires=[0])
             GPI2(0, wires=[1])
             MS(0, 0.5, wires=[1, 2])
-            qml.probs(wires=[0, 1, 2])
-        with qml.tape.QuantumTape(shots=1024) as tape2:
+            qp.probs(wires=[0, 1, 2])
+        with qp.tape.QuantumTape(shots=1024) as tape2:
             GPI2(0, wires=[0])
             GPI(0.5, wires=[1])
             MS(0, 0.5, wires=[1, 2])
-            qml.probs(wires=[0, 1, 2])
+            qp.probs(wires=[0, 1, 2])
         results = dev.batch_execute([tape1, tape2])
         assert np.array_equal(results[0], [0.0, 0.0, 0.0, 0.0, 0.25, 0.25, 0.25, 0.25])
         assert np.array_equal(results[1], [0.0, 0.25, 0.25, 0.0, 0.0, 0.25, 0.25, 0.0])
@@ -645,21 +644,21 @@ you want to access must be first set via the set_current_circuit_index device me
         """Test batch_execute method with shot vector."""
         dev = SimulatorDevice(wires=(0, 1, 2), gateset="native", shots=1024)
         dev._shot_vector = (ShotCopies(1, 3),)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0, wires=[0])
-            qml.probs(wires=[0])
+            qp.probs(wires=[0])
         results = dev.batch_execute([tape1])
         assert len(results[0]) == 3
 
     def test_batch_execute_variance(self, requires_api):
         """Test batch_execute method when computing variance of an observable."""
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0, wires=[0])
-            qml.var(qml.PauliZ(0))
-        with qml.tape.QuantumTape(shots=1024) as tape2:
+            qp.var(qp.PauliZ(0))
+        with qp.tape.QuantumTape(shots=1024) as tape2:
             GPI2(0, wires=[0])
-            qml.var(qml.PauliZ(0))
+            qp.var(qp.PauliZ(0))
         results = dev.batch_execute([tape1, tape2])
         assert results[0] == pytest.approx(0, abs=0.01)
         assert results[1] == pytest.approx(1, abs=0.01)
@@ -667,12 +666,12 @@ you want to access must be first set via the set_current_circuit_index device me
     def test_batch_execute_expectation_value(self, requires_api):
         """Test batch_execute method when computing expectation value of an observable."""
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0, wires=[0])
-            qml.expval(qml.PauliZ(0))
-        with qml.tape.QuantumTape(shots=1024) as tape2:
+            qp.expval(qp.PauliZ(0))
+        with qp.tape.QuantumTape(shots=1024) as tape2:
             GPI2(0, wires=[0])
-            qml.expval(qml.PauliZ(0))
+            qp.expval(qp.PauliZ(0))
         results = dev.batch_execute([tape1, tape2])
         assert results[0] == pytest.approx(-1, abs=0.1)
         assert results[1] == pytest.approx(0, abs=0.1)
@@ -681,11 +680,11 @@ you want to access must be first set via the set_current_circuit_index device me
         """Test batch_execute method when computing expectation value of an
         observable that requires rotations for diagonalization."""
         dev = SimulatorDevice(wires=(0,), gateset="qis", shots=1024)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
-            qml.Hadamard(0)
-            qml.expval(qml.PauliX(0))
-        with qml.tape.QuantumTape(shots=1024) as tape2:
-            qml.expval(qml.PauliX(0))
+        with qp.tape.QuantumTape(shots=1024) as tape1:
+            qp.Hadamard(0)
+            qp.expval(qp.PauliX(0))
+        with qp.tape.QuantumTape(shots=1024) as tape2:
+            qp.expval(qp.PauliX(0))
         results = dev.batch_execute([tape1, tape2])
         assert results[0] == pytest.approx(1, abs=0.1)
         assert results[1] == pytest.approx(0, abs=0.1)
@@ -695,12 +694,12 @@ you want to access must be first set via the set_current_circuit_index device me
         previously set when multiple circuits are submitted in one job.
         """
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0, wires=[0])
-            qml.probs(wires=[0])
-        with qml.tape.QuantumTape(shots=1024) as tape2:
+            qp.probs(wires=[0])
+        with qp.tape.QuantumTape(shots=1024) as tape2:
             GPI2(0, wires=[0])
-            qml.probs(wires=[0])
+            qp.probs(wires=[0])
         dev.batch_execute([tape1, tape2])
         with pytest.raises(
             CircuitIndexNotSetException,
@@ -712,12 +711,12 @@ you want to access must be first set via the set_current_circuit_index device me
     def test_batch_execute_prob_property(self, requires_api):
         """Test batch_execute method with invoking invoking prob device property."""
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0, wires=[0])
-            qml.sample(qml.PauliZ(0))
-        with qml.tape.QuantumTape(shots=1024) as tape2:
+            qp.sample(qp.PauliZ(0))
+        with qp.tape.QuantumTape(shots=1024) as tape2:
             GPI2(0, wires=[0])
-            qml.sample(qml.PauliZ(0))
+            qp.sample(qp.PauliZ(0))
         dev.batch_execute([tape1, tape2])
         dev.set_current_circuit_index(0)
         prob0 = dev.prob
@@ -729,12 +728,12 @@ you want to access must be first set via the set_current_circuit_index device me
     def test_batch_execute_counts(self, requires_api):
         """Test batch_execute method when computing counts."""
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0, wires=[0])
-            qml.counts(qml.PauliZ(0))
-        with qml.tape.QuantumTape(shots=1024) as tape2:
+            qp.counts(qp.PauliZ(0))
+        with qp.tape.QuantumTape(shots=1024) as tape2:
             GPI2(0, wires=[0])
-            qml.counts(qml.PauliZ(0))
+            qp.counts(qp.PauliZ(0))
         results = dev.batch_execute([tape1, tape2])
         assert results[0][-1] == 1024
         assert results[1][-1] == pytest.approx(512, abs=100)
@@ -749,7 +748,7 @@ you want to access must be first set via the set_current_circuit_index device me
                 super().__init__(wires=wires)
 
             def process_samples(self, samples, wire_order, shot_range=None, bin_size=None):
-                counts_mp = qml.counts(wires=self._wires)
+                counts_mp = qp.counts(wires=self._wires)
                 counts = counts_mp.process_samples(samples, wire_order, shot_range, bin_size)
                 return float(counts.get(self.state, 0))
 
@@ -761,11 +760,11 @@ you want to access must be first set via the set_current_circuit_index device me
 
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
 
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0, wires=[0])
             CountState(state="1")
 
-        with qml.tape.QuantumTape(shots=1024) as tape2:
+        with qp.tape.QuantumTape(shots=1024) as tape2:
             GPI2(0, wires=[0])
             CountState(state="1")
 
@@ -786,8 +785,8 @@ class TestJobAttribute:
         mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
         dev = IonQDevice(wires=(0,), target="foo", shots=1024)
 
-        with qml.tape.QuantumTape() as tape:
-            qml.PauliX(0)
+        with qp.tape.QuantumTape() as tape:
+            qp.PauliX(0)
 
         dev.apply(tape.operations)
 
@@ -810,8 +809,8 @@ class TestJobAttribute:
         mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
         dev = IonQDevice(wires=(0,), target="foo", shots=1024)
 
-        with qml.tape.QuantumTape() as tape:
-            qml.PauliX(0)
+        with qp.tape.QuantumTape() as tape:
+            qp.PauliX(0)
 
         dev.reset(circuits_array_length=1)
         dev.batch_apply(tape.operations, circuit_index=0)
@@ -835,8 +834,8 @@ class TestJobAttribute:
         mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
         dev = IonQDevice(wires=(0,), target="foo")
 
-        with qml.tape.QuantumTape() as tape:
-            qml.PauliX(0)
+        with qp.tape.QuantumTape() as tape:
+            qp.PauliX(0)
 
         dev.reset(circuits_array_length=2)
         dev.batch_apply(tape.operations, circuit_index=0)
@@ -866,9 +865,9 @@ class TestJobAttribute:
         mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
         dev = IonQDevice(wires=(0,))
 
-        with qml.tape.QuantumTape() as tape:
-            qml.RX(1.2345, wires=0)
-            qml.RY(qml.numpy.array(2.3456), wires=0)
+        with qp.tape.QuantumTape() as tape:
+            qp.RX(1.2345, wires=0)
+            qp.RY(qp.numpy.array(2.3456), wires=0)
 
         dev.apply(tape.operations)
 
@@ -897,9 +896,9 @@ class TestJobAttribute:
         mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
         dev = IonQDevice(wires=(0,), shots=1024)
 
-        with qml.tape.QuantumTape() as tape:
-            qml.RX(1.2345, wires=0)
-            qml.RY(qml.numpy.array(2.3456), wires=0)
+        with qp.tape.QuantumTape() as tape:
+            qp.RX(1.2345, wires=0)
+            qp.RY(qp.numpy.array(2.3456), wires=0)
 
         dev.reset(circuits_array_length=1)
         dev.batch_apply(tape.operations, circuit_index=0)
@@ -928,9 +927,9 @@ class TestJobAttribute:
         mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
         dev = IonQDevice(wires=(0,))
 
-        with qml.tape.QuantumTape() as tape:
-            qml.RX(1.2345, wires=0)
-            qml.RY(qml.numpy.array(2.3456), wires=0)
+        with qp.tape.QuantumTape() as tape:
+            qp.RX(1.2345, wires=0)
+            qp.RY(qp.numpy.array(2.3456), wires=0)
 
         dev.reset(circuits_array_length=2)
         dev.batch_apply(tape.operations, circuit_index=0)
@@ -972,7 +971,7 @@ class TestJobAttribute:
         mocker.patch("pennylane_ionq.device.IonQDevice._submit_job", mock_submit_job)
         dev = IonQDevice(wires=(0, 1, 2), gateset="native", shots=1024)
 
-        with qml.tape.QuantumTape() as tape:
+        with qp.tape.QuantumTape() as tape:
             GPI(0.1, wires=[0])
             GPI2(0.2, wires=[1])
             MS(0.2, 0.3, wires=[1, 2])
@@ -1020,10 +1019,10 @@ class TestJobAttribute:
         mocker.patch("pennylane_ionq.device.SimulatorDevice._submit_job", mock_submit_job)
         dev = SimulatorDevice(wires=(0,), gateset="native")
 
-        with qml.tape.QuantumTape(shots=1024) as tape:
+        with qp.tape.QuantumTape(shots=1024) as tape:
             GPI(0.7, wires=[0])
             GPI2(0.8, wires=[0])
-            qml.expval(qml.PauliZ(0))
+            qp.expval(qp.PauliZ(0))
 
         try:
             dev.batch_execute([tape])
@@ -1058,13 +1057,13 @@ class TestJobAttribute:
         mocker.patch("pennylane_ionq.device.SimulatorDevice._submit_job", mock_submit_job)
         dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024)
 
-        with qml.tape.QuantumTape(shots=1024) as tape1:
+        with qp.tape.QuantumTape(shots=1024) as tape1:
             GPI(0.7, wires=[0])
             GPI2(0.8, wires=[0])
-            qml.expval(qml.PauliZ(0))
-        with qml.tape.QuantumTape(shots=1024) as tape2:
+            qp.expval(qp.PauliZ(0))
+        with qp.tape.QuantumTape(shots=1024) as tape2:
             GPI2(0.9, wires=[0])
-            qml.expval(qml.PauliZ(0))
+            qp.expval(qp.PauliZ(0))
 
         try:
             dev.batch_execute([tape1, tape2])
@@ -1132,17 +1131,17 @@ class TestJobAttribute:
 
     def test_simple_operations_SWAP_gate(self, requires_api):
         """Test SWAP gate operation is correctly processed and sent to IonQ."""
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        dev = qp.device("ionq.simulator", wires=2, gateset="qis")
 
-        with qml.tape.QuantumTape(shots=1024) as tape:
-            qml.PauliX(wires=0)
-            qml.SWAP(wires=[0, 1])
-            qml.probs(wires=[0, 1])
+        with qp.tape.QuantumTape(shots=1024) as tape:
+            qp.PauliX(wires=0)
+            qp.SWAP(wires=[0, 1])
+            qp.probs(wires=[0, 1])
 
         result_ionq = dev.execute([tape])
 
-        simulator = qml.device("default.qubit", wires=2)
-        result_simulator = qml.execute([tape.copy(shots=None)], simulator)
+        simulator = qp.device("default.qubit", wires=2)
+        result_simulator = qp.execute([tape.copy(shots=None)], simulator)
 
         assert np.allclose(
             result_ionq, result_simulator, atol=1e-5
@@ -1150,17 +1149,17 @@ class TestJobAttribute:
 
     def test_simple_operations_controlled_gate(self, requires_api):
         """Test a controlled gate operation is correctly processed and sent to IonQ."""
-        dev = qml.device("ionq.simulator", wires=2, gateset="qis")
+        dev = qp.device("ionq.simulator", wires=2, gateset="qis")
 
-        with qml.tape.QuantumTape(shots=1024) as tape:
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.probs(wires=[0, 1])
+        with qp.tape.QuantumTape(shots=1024) as tape:
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.probs(wires=[0, 1])
 
         result_ionq = dev.execute([tape])
 
-        simulator = qml.device("default.qubit", wires=2)
-        result_simulator = qml.execute([tape.copy(shots=None)], simulator)
+        simulator = qp.device("default.qubit", wires=2)
+        result_simulator = qp.execute([tape.copy(shots=None)], simulator)
 
         assert np.allclose(
             result_ionq, result_simulator, atol=1e-5
@@ -1169,9 +1168,9 @@ class TestJobAttribute:
     @pytest.mark.parametrize(
         "gate_class, expected_ionq_gate",
         [
-            (qml.IsingXX, "xx"),
-            (qml.IsingYY, "yy"),
-            (qml.IsingZZ, "zz"),
+            (qp.IsingXX, "xx"),
+            (qp.IsingYY, "yy"),
+            (qp.IsingZZ, "zz"),
             (XX, "xx"),
             (YY, "yy"),
             (ZZ, "zz"),

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1213,12 +1213,7 @@ def _mcm_tape():
 class TestMidCircuitMeasurement:
     """Tests for routing mid-circuit measurement and reset through the
     ionq.qasm3.v1 submission path. Classically controlled operations
-    (qp.cond) are rejected with a clear error.
-
-    These tests mirror the ones added to qiskit-ionq in "feat: mid-circuit
-    measurement via ionq.qasm3.v1" (qiskit-ionq #258) and are written
-    test-driven: the feature is not implemented yet.
-    """
+    (qp.cond) are rejected with a clear error."""
 
     def test_requires_qasm3_mcm(self):
         """Reusing a qubit after a mid-circuit measurement requires the qasm3 path."""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,6 +15,7 @@
 
 import json
 import logging
+import warnings
 import numpy as np
 import pennylane as qp
 import pytest
@@ -573,6 +574,28 @@ class TestDeviceIntegration:
             UserWarning,
             match="Circuit is empty. Empty circuits return failures. Submitting anyway.",
         ):
+            dev.batch_execute([tape1])
+
+    @pytest.mark.parametrize("postselect_mode", ["hw-like", "fill-shots"])
+    def test_batch_execute_postselect_mode_warns(self, monkeypatch, postselect_mode):
+        """An explicitly set postselect_mode raises a UserWarning and is ignored."""
+        monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
+        dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024, dry_run=True)
+        with qp.tape.QuantumTape(shots=1024) as tape1:
+            GPI(0, wires=[0])
+            qp.probs(wires=[0])
+        with pytest.warns(UserWarning, match="'postselect_mode' is ignored"):
+            dev.batch_execute([tape1], postselect_mode=postselect_mode)
+
+    def test_batch_execute_postselect_mode_default_no_warning(self, monkeypatch):
+        """The default postselect_mode=None does not warn."""
+        monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
+        dev = SimulatorDevice(wires=(0,), gateset="native", shots=1024, dry_run=True)
+        with qp.tape.QuantumTape(shots=1024) as tape1:
+            GPI(0, wires=[0])
+            qp.probs(wires=[0])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             dev.batch_execute([tape1])
 
     @mock.patch("logging.Logger.isEnabledFor", return_value=True)
@@ -1335,7 +1358,7 @@ class TestMidCircuitMeasurement:
         assert "stdgates.inc" not in data
         assert "gpi(0.5) q[0];" in data
         assert "reset q[0];" in data
-        assert "ms(0,0.5,0.25) q[0],q[1];" in data
+        assert "ms(0,0.5,0.25) q[0], q[1];" in data
 
     def test_multi_circuit_mcm_raises(self, monkeypatch):
         """Multi-circuit MCM submissions are rejected with a clear error."""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1214,12 +1214,13 @@ class TestJobAttribute:
 
 
 def _mcm_tape():
-    """1-qubit mid-circuit-measurement tape (the API schema example)."""
+    """1-qubit mid-circuit-measurement tape with a qubit reset (the API
+    schema example)."""
     with qp.tape.QuantumTape(shots=1024) as tape:
         qp.Hadamard(0)
         qp.measure(0)
         qp.PauliX(0)
-        qp.measure(0)
+        qp.measure(0, reset=True)
         qp.PauliX(0)
         qp.measure(0)
         qp.probs(wires=0)
@@ -1229,7 +1230,7 @@ def _mcm_tape():
 class TestMidCircuitMeasurement:
     """Tests for routing mid-circuit measurement and reset through the
     ionq.qasm3.v1 submission path. Classically controlled operations
-    (qp.cond) are rejected with a clear error."""
+    (qp.cond) and postselection are rejected with a clear error."""
 
     def test_requires_qasm3_mcm(self):
         """Reusing a qubit after a mid-circuit measurement requires the qasm3 path."""
@@ -1270,6 +1271,18 @@ class TestMidCircuitMeasurement:
             measurement()
         assert circuit_requires_qasm3(tape) is False
 
+    def test_postselect_raises(self, monkeypatch):
+        """A mid-circuit measurement with postselection is rejected."""
+        monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
+        dev = IonQDevice(wires=(0,), shots=1024)
+        with qp.tape.QuantumTape(shots=1024) as tape:
+            qp.Hadamard(0)
+            qp.measure(0, postselect=0)
+            qp.PauliX(0)
+            qp.probs(wires=0)
+        with pytest.raises(NotImplementedError, match="postselection"):
+            dev.apply(tape.operations)
+
     def test_cond_else_raises(self):
         """A conditional with both true and false branches is not supported."""
         with qp.tape.QuantumTape() as tape:
@@ -1299,10 +1312,11 @@ class TestMidCircuitMeasurement:
         assert dev.job["shots"] == 1024
         data = dev.job["input"]["data"]
         assert data.startswith("OPENQASM 3.0;")
-        # Exactly the operations we built (1 H, 2 X, 3 measure) and nothing injected.
+        # Exactly the operations we built (1 H, 2 X, 3 measure, 1 reset) and nothing injected.
         assert data.count("measure") == 3
         assert data.count("h q") == 1
         assert data.count("x q") == 2
+        assert data.count("reset q") == 1
 
     def test_qasm3_settings_passthrough(self, monkeypatch):
         """compilation and error_mitigation settings flow through on the qasm3 path."""
@@ -1313,6 +1327,12 @@ class TestMidCircuitMeasurement:
             compilation={"opt": 0},
             error_mitigation={"debiasing": False},
         )
+
+        # Before apply, the job is a plain v1 payload with the settings
+        # verbatim; service_version is only pinned on the qasm3 path.
+        assert dev.job["type"] == "ionq.circuit.v1"
+        assert dev.job["settings"]["compilation"] == {"opt": 0}
+        assert dev.job["settings"]["error_mitigation"] == {"debiasing": False}
 
         dev.apply(_mcm_tape().operations)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1190,3 +1190,156 @@ class TestJobAttribute:
         assert "control" not in gate
         assert "target" not in gate
         assert gate["rotation"] == rotation
+
+
+def _requires_qasm3(tape):
+    """Deferred import so that collecting this module does not fail while the
+    TDD target ``circuit_requires_qasm3`` is not implemented yet."""
+    from pennylane_ionq.device import circuit_requires_qasm3
+
+    return circuit_requires_qasm3(tape)
+
+
+def _mcm_tape():
+    """1-qubit mid-circuit-measurement tape (the API schema example)."""
+    with qml.tape.QuantumTape(shots=1024) as tape:
+        qml.Hadamard(0)
+        qml.measure(0)
+        qml.PauliX(0)
+        qml.measure(0)
+        qml.PauliX(0)
+        qml.measure(0)
+        qml.probs(wires=0)
+    return tape
+
+
+class TestMidCircuitMeasurement:
+    """Tests for routing mid-circuit measurement, reset, and classical control
+    flow through the ionq.qasm3.v1 submission path.
+
+    These tests mirror the ones added to qiskit-ionq in "feat: mid-circuit
+    measurement via ionq.qasm3.v1" (qiskit-ionq #258) and are written
+    test-driven: the feature is not implemented yet.
+    """
+
+    def test_requires_qasm3_mcm(self):
+        """Reusing a qubit after a mid-circuit measurement requires the qasm3 path."""
+        assert _requires_qasm3(_mcm_tape()) is True
+
+    def test_requires_qasm3_reset(self):
+        """A mid-circuit measurement with reset requires the qasm3 path."""
+        with qml.tape.QuantumTape() as tape:
+            qml.Hadamard(0)
+            qml.measure(0, reset=True)
+            qml.PauliX(0)
+        assert _requires_qasm3(tape) is True
+
+    def test_requires_qasm3_cond(self):
+        """Classically controlled operations (qml.cond) require the qasm3 path."""
+        with qml.tape.QuantumTape() as tape:
+            qml.Hadamard(0)
+            m = qml.measure(0)
+            qml.cond(m, qml.PauliX)(0)
+        assert _requires_qasm3(tape) is True
+
+    @pytest.mark.parametrize(
+        "measurement",
+        [
+            pytest.param(lambda: qml.expval(qml.PauliZ(0)), id="expval"),
+            pytest.param(lambda: qml.var(qml.PauliZ(0)), id="var"),
+            pytest.param(lambda: qml.probs(wires=[0, 1]), id="probs"),
+            pytest.param(lambda: qml.sample(qml.PauliZ(0)), id="sample"),
+            pytest.param(lambda: qml.counts(), id="counts"),
+        ],
+    )
+    def test_requires_qasm3_plain(self, measurement):
+        """A plain terminal-measurement tape stays on the v1 path."""
+        with qml.tape.QuantumTape() as tape:
+            qml.Hadamard(0)
+            qml.CNOT(wires=[0, 1])
+            measurement()
+        assert _requires_qasm3(tape) is False
+
+    def test_requires_qasm3_cond_else(self):
+        """A conditional with both true and false branches requires the qasm3 path."""
+        with qml.tape.QuantumTape() as tape:
+            qml.Hadamard(0)
+            m = qml.measure(0)
+            qml.cond(m, qml.PauliX, qml.PauliZ)(0)
+        assert _requires_qasm3(tape) is True
+
+    def test_requires_qasm3_reuse(self):
+        """A gate after a mid-circuit measurement (qubit reuse) requires the qasm3 path."""
+        with qml.tape.QuantumTape() as tape:
+            qml.Hadamard(0)
+            qml.measure(0)
+            qml.PauliX(0)
+        assert _requires_qasm3(tape) is True
+
+    def test_qasm3_payload_shape(self, monkeypatch):
+        """MCM tapes serialize to an ionq.qasm3.v1 payload with QASM 3 input."""
+        monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
+        dev = IonQDevice(wires=(0,), shots=1024)
+
+        dev.apply(_mcm_tape().operations)
+
+        assert dev.job["type"] == "ionq.qasm3.v1"
+        assert dev.job["input"]["qubits"] == 1
+        assert dev.job["shots"] == 1024
+        data = dev.job["input"]["data"]
+        assert data.startswith("OPENQASM 3.0;")
+        # Exactly the operations we built (1 H, 2 X, 3 measure) and nothing injected.
+        assert data.count("measure") == 3
+        assert data.count("h q") == 1
+        assert data.count("x q") == 2
+
+    def test_qasm3_settings_passthrough(self, monkeypatch):
+        """compilation and error_mitigation settings flow through on the qasm3 path."""
+        monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
+        dev = IonQDevice(
+            wires=(0,),
+            shots=1024,
+            compilation={"opt": 0},
+            error_mitigation={"debiasing": False},
+        )
+
+        dev.apply(_mcm_tape().operations)
+
+        assert dev.job["type"] == "ionq.qasm3.v1"
+        assert dev.job["settings"]["compilation"] == {"opt": 0}
+        assert dev.job["settings"]["error_mitigation"] == {"debiasing": False}
+
+    def test_multi_circuit_mcm_raises(self, monkeypatch):
+        """Multi-circuit MCM submissions are rejected with a clear error."""
+        monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
+        dev = IonQDevice(wires=(0,), shots=1024)
+
+        with pytest.raises(ValueError, match="single-circuit"):
+            dev.batch_execute([_mcm_tape(), _mcm_tape()])
+
+    def test_qasm3_simulator_noise(self, monkeypatch):
+        """MCM on the simulator carries the noise block, like the v1 path."""
+        monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
+        dev = SimulatorDevice(wires=(0,), shots=1024, noise_model="ideal")
+
+        dev.apply(_mcm_tape().operations)
+
+        assert dev.job["type"] == "ionq.qasm3.v1"
+        assert dev.job["backend"] == "simulator"
+        assert dev.job["noise"]["model"] == "ideal"
+
+    def test_qasm3_reset_payload(self, monkeypatch):
+        """A mid-circuit reset routes to qasm3 and the reset survives export."""
+        monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
+        dev = IonQDevice(wires=(0,), shots=1024)
+
+        with qml.tape.QuantumTape() as tape:
+            qml.Hadamard(0)
+            qml.measure(0, reset=True)
+            qml.PauliX(0)
+            qml.probs(wires=0)
+
+        dev.apply(tape.operations)
+
+        assert dev.job["type"] == "ionq.qasm3.v1"
+        assert "reset" in dev.job["input"]["data"]

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -17,6 +17,7 @@ import json
 import logging
 import numpy as np
 import pennylane as qml
+import pennylane as qp
 import pytest
 import requests
 
@@ -1202,21 +1203,21 @@ def _requires_qasm3(tape):
 
 def _mcm_tape():
     """1-qubit mid-circuit-measurement tape (the API schema example)."""
-    with qml.tape.QuantumTape(shots=1024) as tape:
-        qml.Hadamard(0)
-        qml.measure(0)
-        qml.PauliX(0)
-        qml.measure(0)
-        qml.PauliX(0)
-        qml.measure(0)
-        qml.probs(wires=0)
+    with qp.tape.QuantumTape(shots=1024) as tape:
+        qp.Hadamard(0)
+        qp.measure(0)
+        qp.PauliX(0)
+        qp.measure(0)
+        qp.PauliX(0)
+        qp.measure(0)
+        qp.probs(wires=0)
     return tape
 
 
 class TestMidCircuitMeasurement:
     """Tests for routing mid-circuit measurement and reset through the
     ionq.qasm3.v1 submission path. Classically controlled operations
-    (qml.cond) are rejected with a clear error.
+    (qp.cond) are rejected with a clear error.
 
     These tests mirror the ones added to qiskit-ionq in "feat: mid-circuit
     measurement via ionq.qasm3.v1" (qiskit-ionq #258) and are written
@@ -1229,54 +1230,54 @@ class TestMidCircuitMeasurement:
 
     def test_requires_qasm3_reset(self):
         """A mid-circuit measurement with reset requires the qasm3 path."""
-        with qml.tape.QuantumTape() as tape:
-            qml.Hadamard(0)
-            qml.measure(0, reset=True)
-            qml.PauliX(0)
+        with qp.tape.QuantumTape() as tape:
+            qp.Hadamard(0)
+            qp.measure(0, reset=True)
+            qp.PauliX(0)
         assert _requires_qasm3(tape) is True
 
     def test_cond_raises(self):
-        """Classically controlled operations (qml.cond) are not supported."""
-        with qml.tape.QuantumTape() as tape:
-            qml.Hadamard(0)
-            m = qml.measure(0)
-            qml.cond(m, qml.PauliX)(0)
-        with pytest.raises(ValueError, match="qml.cond.*not supported"):
+        """Classically controlled operations (qp.cond) are not supported."""
+        with qp.tape.QuantumTape() as tape:
+            qp.Hadamard(0)
+            m = qp.measure(0)
+            qp.cond(m, qp.PauliX)(0)
+        with pytest.raises(ValueError, match="qp.cond.*not supported"):
             _requires_qasm3(tape)
 
     @pytest.mark.parametrize(
         "measurement",
         [
-            pytest.param(lambda: qml.expval(qml.PauliZ(0)), id="expval"),
-            pytest.param(lambda: qml.var(qml.PauliZ(0)), id="var"),
-            pytest.param(lambda: qml.probs(wires=[0, 1]), id="probs"),
-            pytest.param(lambda: qml.sample(qml.PauliZ(0)), id="sample"),
-            pytest.param(lambda: qml.counts(), id="counts"),
+            pytest.param(lambda: qp.expval(qp.PauliZ(0)), id="expval"),
+            pytest.param(lambda: qp.var(qp.PauliZ(0)), id="var"),
+            pytest.param(lambda: qp.probs(wires=[0, 1]), id="probs"),
+            pytest.param(lambda: qp.sample(qp.PauliZ(0)), id="sample"),
+            pytest.param(lambda: qp.counts(), id="counts"),
         ],
     )
     def test_requires_qasm3_plain(self, measurement):
         """A plain terminal-measurement tape stays on the v1 path."""
-        with qml.tape.QuantumTape() as tape:
-            qml.Hadamard(0)
-            qml.CNOT(wires=[0, 1])
+        with qp.tape.QuantumTape() as tape:
+            qp.Hadamard(0)
+            qp.CNOT(wires=[0, 1])
             measurement()
         assert _requires_qasm3(tape) is False
 
     def test_cond_else_raises(self):
         """A conditional with both true and false branches is not supported."""
-        with qml.tape.QuantumTape() as tape:
-            qml.Hadamard(0)
-            m = qml.measure(0)
-            qml.cond(m, qml.PauliX, qml.PauliZ)(0)
-        with pytest.raises(ValueError, match="qml.cond.*not supported"):
+        with qp.tape.QuantumTape() as tape:
+            qp.Hadamard(0)
+            m = qp.measure(0)
+            qp.cond(m, qp.PauliX, qp.PauliZ)(0)
+        with pytest.raises(ValueError, match="qp.cond.*not supported"):
             _requires_qasm3(tape)
 
     def test_requires_qasm3_reuse(self):
         """A gate after a mid-circuit measurement (qubit reuse) requires the qasm3 path."""
-        with qml.tape.QuantumTape() as tape:
-            qml.Hadamard(0)
-            qml.measure(0)
-            qml.PauliX(0)
+        with qp.tape.QuantumTape() as tape:
+            qp.Hadamard(0)
+            qp.measure(0)
+            qp.PauliX(0)
         assert _requires_qasm3(tape) is True
 
     def test_qasm3_payload_shape(self, monkeypatch):
@@ -1330,11 +1331,11 @@ class TestMidCircuitMeasurement:
         monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
         dev = IonQDevice(wires=2, shots=1024, gateset="native")
 
-        with qml.tape.QuantumTape() as tape:
+        with qp.tape.QuantumTape() as tape:
             GPI(0.5, wires=[0])
-            qml.measure(0, reset=True)
+            qp.measure(0, reset=True)
             MS(0, 0.5, wires=[0, 1])
-            qml.probs(wires=[0, 1])
+            qp.probs(wires=[0, 1])
 
         dev.apply(tape.operations)
 
@@ -1369,11 +1370,11 @@ class TestMidCircuitMeasurement:
         monkeypatch.setattr(IonQDevice, "_submit_job", lambda self: None)
         dev = IonQDevice(wires=(0,), shots=1024)
 
-        with qml.tape.QuantumTape() as tape:
-            qml.Hadamard(0)
-            qml.measure(0, reset=True)
-            qml.PauliX(0)
-            qml.probs(wires=0)
+        with qp.tape.QuantumTape() as tape:
+            qp.Hadamard(0)
+            qp.measure(0, reset=True)
+            qp.PauliX(0)
+            qp.probs(wires=0)
 
         dev.apply(tape.operations)
 

--- a/tests/test_qasm3.py
+++ b/tests/test_qasm3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Tests for the to_qasm3 serializer.
+Tests for the OpenQASM 3.0 serializer.
 """
 import pytest
 
@@ -20,7 +20,7 @@ import pennylane as qp
 from pennylane.measurements import MidMeasureMP
 from pennylane.wires import Wires
 
-from pennylane_ionq import GPI, GPI2, MS, XX, YY, ZZ, to_qasm3
+from pennylane_ionq import GPI, GPI2, MS, XX, YY, ZZ
 from pennylane_ionq.qasm3 import operations_to_qasm3
 
 
@@ -35,51 +35,29 @@ def _mid_measure(wire, reset=False, postselect=None):
     return MidMeasureMP(Wires(wire), reset=reset, postselect=postselect)
 
 
-class TestToQasm3:
-    """Tests serializing circuits to OpenQASM 3.0 programs."""
+class TestOperationsToQasm3:
+    """Tests serializing operation lists to OpenQASM 3.0 programs."""
 
-    def test_basic_circuit(self):
-        """A plain circuit serializes with header, registers, gates, and
-        terminal measurements on all wires."""
-        tape = qp.tape.QuantumScript(
-            [qp.Hadamard(0), qp.CNOT(wires=[0, 1])], [qp.sample()]
-        )
-        qasm = to_qasm3(tape)
+    def test_basic_program(self):
+        """A plain operation list serializes with header, qubit register, and
+        gates, without terminal measurements."""
+        qasm = operations_to_qasm3([qp.Hadamard(0), qp.CNOT(wires=[0, 1])], wires=[0, 1])
         expected = "\n".join(
             [
                 "OPENQASM 3.0;",
                 'include "stdgates.inc";',
                 "qubit[2] q;",
-                "bit[2] c;",
                 "h q[0];",
                 "cx q[0],q[1];",
-                "c[0] = measure q[0];",
-                "c[1] = measure q[1];",
             ]
         )
         assert qasm == expected + "\n"
         _parse(qasm)
 
-    def test_qnode_input(self):
-        """A QNode input returns a wrapper that accepts the QNode arguments."""
-        dev = qp.device("default.qubit", wires=2)
-
-        @qp.qnode(dev)
-        def circuit(theta):
-            qp.RX(theta, wires=0)
-            qp.CNOT(wires=[0, 1])
-            return qp.sample()
-
-        qasm = to_qasm3(circuit)(0.5)
-        assert "rx(0.5) q[0];" in qasm
-        _parse(qasm)
-
     def test_mid_measure(self):
         """Mid-circuit measurements are recorded in the mcms register."""
-        tape = qp.tape.QuantumScript(
-            [qp.Hadamard(0), _mid_measure(0), qp.PauliX(1)], [qp.sample()]
-        )
-        qasm = to_qasm3(tape)
+        ops = [qp.Hadamard(0), _mid_measure(0), qp.PauliX(1)]
+        qasm = operations_to_qasm3(ops, wires=[0, 1])
         assert "bit[1] mcms;" in qasm
         assert "mcms[0] = measure q[0];" in qasm
         assert "reset" not in qasm
@@ -88,152 +66,8 @@ class TestToQasm3:
     def test_mid_measure_reset(self):
         """A mid-circuit measurement with reset emits an explicit reset,
         enabling qubit reuse."""
-        tape = qp.tape.QuantumScript(
-            [qp.Hadamard(0), _mid_measure(0, reset=True), qp.PauliX(0)],
-            [qp.sample()],
-        )
-        qasm = to_qasm3(tape)
-        lines = qasm.splitlines()
-        measure_index = lines.index("mcms[0] = measure q[0];")
-        assert lines[measure_index + 1] == "reset q[0];"
-        assert lines[measure_index + 2] == "x q[0];"
-        _parse(qasm)
-
-    def test_multiple_mid_measures(self):
-        """Multiple mid-circuit measurements get consecutive mcms bits in
-        circuit order."""
-        tape = qp.tape.QuantumScript(
-            [
-                qp.Hadamard(0),
-                _mid_measure(0, reset=True),
-                qp.CNOT(wires=[0, 1]),
-                _mid_measure(1),
-            ],
-            [qp.sample()],
-        )
-        qasm = to_qasm3(tape)
-        assert "bit[2] mcms;" in qasm
-        assert "mcms[0] = measure q[0];" in qasm
-        assert "mcms[1] = measure q[1];" in qasm
-        _parse(qasm)
-
-    def test_postselect_raises(self):
-        """Postselecting mid-circuit measurements are not supported."""
-        tape = qp.tape.QuantumScript(
-            [qp.Hadamard(0), _mid_measure(0, postselect=0)], [qp.sample()]
-        )
-        with pytest.raises(NotImplementedError, match="postselection"):
-            to_qasm3(tape)
-
-    def test_conditional_raises(self):
-        """Classically controlled operations (qp.cond) are out of scope."""
-        with qp.tape.QuantumTape() as tape:
-            qp.Hadamard(0)
-            m = qp.measure(0)
-            qp.cond(m, qp.PauliX)(0)
-            qp.sample()
-        with pytest.raises(ValueError):
-            to_qasm3(tape)
-
-    def test_unsupported_gate_raises(self):
-        """A gate with no QASM spelling and no decomposition raises."""
-
-        class NoDecompOp(qp.operation.Operation):
-            """Dummy operation with no QASM spelling or decomposition."""
-
-            num_wires = 1
-
-        tape = qp.tape.QuantumScript([NoDecompOp(wires=0)], [qp.sample()])
-        with pytest.raises(ValueError):
-            to_qasm3(tape)
-
-    def test_decomposition_fallback(self):
-        """Gates outside the QASM gate set decompose to supported ones."""
-        tape = qp.tape.QuantumScript([qp.IsingXX(0.5, wires=[0, 1])], [qp.sample()])
-        qasm = to_qasm3(tape)
-        assert "IsingXX" not in qasm
-        _parse(qasm)
-
-    def test_rotations(self):
-        """Diagonalizing gates are appended when rotations=True."""
-        tape = qp.tape.QuantumScript([qp.Hadamard(0)], [qp.expval(qp.PauliX(0))])
-        qasm = to_qasm3(tape)
-        assert qasm.count("h q[0];") == 2
-        assert to_qasm3(tape, rotations=False).count("h q[0];") == 1
-
-    def test_measure_all_false(self):
-        """measure_all=False only measures the terminally measured wires."""
-        tape = qp.tape.QuantumScript(
-            [qp.Hadamard(0), qp.CNOT(wires=[0, 1])], [qp.sample(wires=1)]
-        )
-        qasm = to_qasm3(tape, measure_all=False)
-        assert "bit[1] c;" in qasm
-        assert "c[0] = measure q[1];" in qasm
-        assert "measure q[0];" not in qasm
-        _parse(qasm)
-
-    def test_precision(self):
-        """The precision argument controls parameter formatting."""
-        tape = qp.tape.QuantumScript([qp.RX(0.123456789, wires=0)], [qp.sample()])
-        qasm = to_qasm3(tape, precision=3)
-        assert "rx(0.123) q[0];" in qasm
-
-    def test_global_phase(self):
-        """GlobalPhase emits a gphase statement with no qubit operands and
-        the opposite sign convention."""
-        tape = qp.tape.QuantumScript(
-            [qp.GlobalPhase(0.5), qp.PauliX(0)], [qp.sample()]
-        )
-        qasm = to_qasm3(tape)
-        assert "gphase(-0.5);" in qasm
-        _parse(qasm)
-
-    def test_empty_circuit(self):
-        """A circuit with no wires serializes to just the header."""
-        tape = qp.tape.QuantumScript([], [])
-        assert to_qasm3(tape) == 'OPENQASM 3.0;\ninclude "stdgates.inc";\n'
-
-    @pytest.mark.parametrize("gate_class", [XX, YY, ZZ])
-    def test_plugin_ising_gates_decompose(self, gate_class):
-        """The plugin's Ising gates serialize via their core-gate decomposition."""
-        tape = qp.tape.QuantumScript(
-            [gate_class(0.5, wires=[0, 1]), _mid_measure(0)], [qp.sample()]
-        )
-        qasm = to_qasm3(tape)
-        assert gate_class.__name__ not in qasm
-        assert "mcms[0] = measure q[0];" in qasm
-        _parse(qasm)
-
-    def test_native_gateset(self):
-        """Native gates serialize directly, in turns, without stdgates.inc."""
-        tape = qp.tape.QuantumScript(
-            [
-                GPI(0.5, wires=0),
-                GPI2(0, wires=1),
-                _mid_measure(0, reset=True),
-                MS(0, 0.5, wires=[0, 1]),
-            ],
-            [qp.sample()],
-        )
-        qasm = to_qasm3(tape, gateset="native")
-        assert "stdgates.inc" not in qasm
-        assert "gpi(0.5) q[0];" in qasm
-        assert "gpi2(0) q[1];" in qasm
-        assert "mcms[0] = measure q[0];" in qasm
-        assert "reset q[0];" in qasm
-        assert "ms(0,0.5,0.25) q[0],q[1];" in qasm
-        _parse(qasm)
-
-    def test_native_gateset_rejects_qis_gate(self):
-        """Abstract gates are not serialized into a native-gateset program."""
-        tape = qp.tape.QuantumScript([qp.Hadamard(0)], [qp.sample()])
-        with pytest.raises(ValueError):
-            to_qasm3(tape, gateset="native")
-
-    def test_operations_to_qasm3(self):
-        """The operations-level serializer emits no terminal measurements."""
         ops = [qp.Hadamard(0), _mid_measure(0, reset=True), qp.PauliX(0)]
-        qasm = operations_to_qasm3(ops, wires=Wires([0, 1]))
+        qasm = operations_to_qasm3(ops, wires=[0, 1])
         expected = "\n".join(
             [
                 "OPENQASM 3.0;",
@@ -249,40 +83,100 @@ class TestToQasm3:
         assert qasm == expected + "\n"
         _parse(qasm)
 
-    def test_operations_to_qasm3_custom_wire_labels(self):
-        """Wire labels map to qubit indices by their position in wires."""
-        ops = [qp.Hadamard("b"), _mid_measure("a")]
-        qasm = operations_to_qasm3(ops, wires=Wires(["a", "b"]))
-        assert "h q[1];" in qasm
+    def test_multiple_mid_measures(self):
+        """Multiple mid-circuit measurements get consecutive mcms bits in
+        circuit order."""
+        ops = [
+            qp.Hadamard(0),
+            _mid_measure(0, reset=True),
+            qp.CNOT(wires=[0, 1]),
+            _mid_measure(1),
+        ]
+        qasm = operations_to_qasm3(ops, wires=[0, 1])
+        assert "bit[2] mcms;" in qasm
+        assert "mcms[0] = measure q[0];" in qasm
+        assert "mcms[1] = measure q[1];" in qasm
+        _parse(qasm)
+
+    def test_postselect_raises(self):
+        """Postselecting mid-circuit measurements are not supported."""
+        ops = [qp.Hadamard(0), _mid_measure(0, postselect=0)]
+        with pytest.raises(NotImplementedError, match="postselection"):
+            operations_to_qasm3(ops, wires=[0])
+
+    def test_conditional_raises(self):
+        """Classically controlled operations (qp.cond) are out of scope."""
+        with qp.tape.QuantumTape() as tape:
+            qp.Hadamard(0)
+            m = qp.measure(0)
+            qp.cond(m, qp.PauliX)(0)
+        with pytest.raises(ValueError):
+            operations_to_qasm3(tape.operations, wires=[0])
+
+    def test_unsupported_gate_raises(self):
+        """A gate with no QASM spelling and no decomposition raises."""
+
+        class NoDecompOp(qp.operation.Operation):
+            """Dummy operation with no QASM spelling or decomposition."""
+
+            num_wires = 1
+
+        with pytest.raises(ValueError):
+            operations_to_qasm3([NoDecompOp(wires=0)], wires=[0])
+
+    def test_decomposition_fallback(self):
+        """Gates outside the QASM gate set decompose to supported ones."""
+        qasm = operations_to_qasm3([qp.IsingXX(0.5, wires=[0, 1])], wires=[0, 1])
+        assert "IsingXX" not in qasm
+        _parse(qasm)
+
+    def test_precision(self):
+        """The precision argument controls parameter formatting."""
+        qasm = operations_to_qasm3([qp.RX(0.123456789, wires=0)], wires=[0], precision=3)
+        assert "rx(0.123) q[0];" in qasm
+
+    def test_global_phase(self):
+        """GlobalPhase emits a gphase statement with no qubit operands and
+        the opposite sign convention."""
+        qasm = operations_to_qasm3([qp.GlobalPhase(0.5), qp.PauliX(0)], wires=[0])
+        assert "gphase(-0.5);" in qasm
+        _parse(qasm)
+
+    @pytest.mark.parametrize("gate_class", [XX, YY, ZZ])
+    def test_plugin_ising_gates_decompose(self, gate_class):
+        """The plugin's Ising gates serialize via their core-gate decomposition."""
+        ops = [gate_class(0.5, wires=[0, 1]), _mid_measure(0)]
+        qasm = operations_to_qasm3(ops, wires=[0, 1])
+        assert gate_class.__name__ not in qasm
         assert "mcms[0] = measure q[0];" in qasm
         _parse(qasm)
 
-    def test_mcm_qnode_end_to_end(self):
-        """A QNode with measure-and-reuse serializes to a valid program."""
-        dev = qp.device("default.qubit", wires=2)
+    def test_native_gateset(self):
+        """Native gates serialize directly, in turns, without stdgates.inc."""
+        ops = [
+            GPI(0.5, wires=0),
+            GPI2(0, wires=1),
+            _mid_measure(0, reset=True),
+            MS(0, 0.5, wires=[0, 1]),
+        ]
+        qasm = operations_to_qasm3(ops, wires=[0, 1], gateset="native")
+        assert "stdgates.inc" not in qasm
+        assert "gpi(0.5) q[0];" in qasm
+        assert "gpi2(0) q[1];" in qasm
+        assert "mcms[0] = measure q[0];" in qasm
+        assert "reset q[0];" in qasm
+        assert "ms(0,0.5,0.25) q[0],q[1];" in qasm
+        _parse(qasm)
 
-        @qp.qnode(dev)
-        def circuit():
-            qp.Hadamard(0)
-            qp.measure(0, reset=True)
-            qp.CNOT(wires=[0, 1])
-            return qp.sample()
+    def test_native_gateset_rejects_qis_gate(self):
+        """Abstract gates are not serialized into a native-gateset program."""
+        with pytest.raises(ValueError):
+            operations_to_qasm3([qp.Hadamard(0)], wires=[0], gateset="native")
 
-        qasm = to_qasm3(circuit)()
-        expected = "\n".join(
-            [
-                "OPENQASM 3.0;",
-                'include "stdgates.inc";',
-                "qubit[2] q;",
-                "bit[2] c;",
-                "bit[1] mcms;",
-                "h q[0];",
-                "mcms[0] = measure q[0];",
-                "reset q[0];",
-                "cx q[0],q[1];",
-                "c[0] = measure q[0];",
-                "c[1] = measure q[1];",
-            ]
-        )
-        assert qasm == expected + "\n"
+    def test_custom_wire_labels(self):
+        """Wire labels map to qubit indices by their position in wires."""
+        ops = [qp.Hadamard("b"), _mid_measure("a")]
+        qasm = operations_to_qasm3(ops, wires=["a", "b"])
+        assert "h q[1];" in qasm
+        assert "mcms[0] = measure q[0];" in qasm
         _parse(qasm)

--- a/tests/test_qasm3.py
+++ b/tests/test_qasm3.py
@@ -1,0 +1,288 @@
+# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for the to_qasm3 serializer.
+"""
+import pytest
+
+import pennylane as qml
+from pennylane.measurements import MidMeasureMP
+from pennylane.wires import Wires
+
+from pennylane_ionq import GPI, GPI2, MS, XX, YY, ZZ, to_qasm3
+from pennylane_ionq.qasm3 import operations_to_qasm3
+
+
+def _parse(qasm):
+    """Validate a program against the OpenQASM 3 grammar if the reference
+    parser is available."""
+    openqasm3 = pytest.importorskip("openqasm3")
+    openqasm3.parse(qasm)
+
+
+def _mid_measure(wire, reset=False, postselect=None):
+    return MidMeasureMP(Wires(wire), reset=reset, postselect=postselect)
+
+
+class TestToQasm3:
+    """Tests serializing circuits to OpenQASM 3.0 programs."""
+
+    def test_basic_circuit(self):
+        """A plain circuit serializes with header, registers, gates, and
+        terminal measurements on all wires."""
+        tape = qml.tape.QuantumScript(
+            [qml.Hadamard(0), qml.CNOT(wires=[0, 1])], [qml.sample()]
+        )
+        qasm = to_qasm3(tape)
+        expected = "\n".join(
+            [
+                "OPENQASM 3.0;",
+                'include "stdgates.inc";',
+                "qubit[2] q;",
+                "bit[2] c;",
+                "h q[0];",
+                "cx q[0],q[1];",
+                "c[0] = measure q[0];",
+                "c[1] = measure q[1];",
+            ]
+        )
+        assert qasm == expected + "\n"
+        _parse(qasm)
+
+    def test_qnode_input(self):
+        """A QNode input returns a wrapper that accepts the QNode arguments."""
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit(theta):
+            qml.RX(theta, wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.sample()
+
+        qasm = to_qasm3(circuit)(0.5)
+        assert "rx(0.5) q[0];" in qasm
+        _parse(qasm)
+
+    def test_mid_measure(self):
+        """Mid-circuit measurements are recorded in the mcms register."""
+        tape = qml.tape.QuantumScript(
+            [qml.Hadamard(0), _mid_measure(0), qml.PauliX(1)], [qml.sample()]
+        )
+        qasm = to_qasm3(tape)
+        assert "bit[1] mcms;" in qasm
+        assert "mcms[0] = measure q[0];" in qasm
+        assert "reset" not in qasm
+        _parse(qasm)
+
+    def test_mid_measure_reset(self):
+        """A mid-circuit measurement with reset emits an explicit reset,
+        enabling qubit reuse."""
+        tape = qml.tape.QuantumScript(
+            [qml.Hadamard(0), _mid_measure(0, reset=True), qml.PauliX(0)],
+            [qml.sample()],
+        )
+        qasm = to_qasm3(tape)
+        lines = qasm.splitlines()
+        measure_index = lines.index("mcms[0] = measure q[0];")
+        assert lines[measure_index + 1] == "reset q[0];"
+        assert lines[measure_index + 2] == "x q[0];"
+        _parse(qasm)
+
+    def test_multiple_mid_measures(self):
+        """Multiple mid-circuit measurements get consecutive mcms bits in
+        circuit order."""
+        tape = qml.tape.QuantumScript(
+            [
+                qml.Hadamard(0),
+                _mid_measure(0, reset=True),
+                qml.CNOT(wires=[0, 1]),
+                _mid_measure(1),
+            ],
+            [qml.sample()],
+        )
+        qasm = to_qasm3(tape)
+        assert "bit[2] mcms;" in qasm
+        assert "mcms[0] = measure q[0];" in qasm
+        assert "mcms[1] = measure q[1];" in qasm
+        _parse(qasm)
+
+    def test_postselect_raises(self):
+        """Postselecting mid-circuit measurements are not supported."""
+        tape = qml.tape.QuantumScript(
+            [qml.Hadamard(0), _mid_measure(0, postselect=0)], [qml.sample()]
+        )
+        with pytest.raises(NotImplementedError, match="postselection"):
+            to_qasm3(tape)
+
+    def test_conditional_raises(self):
+        """Classically controlled operations (qml.cond) are out of scope."""
+        with qml.tape.QuantumTape() as tape:
+            qml.Hadamard(0)
+            m = qml.measure(0)
+            qml.cond(m, qml.PauliX)(0)
+            qml.sample()
+        with pytest.raises(ValueError):
+            to_qasm3(tape)
+
+    def test_unsupported_gate_raises(self):
+        """A gate with no QASM spelling and no decomposition raises."""
+
+        class NoDecompOp(qml.operation.Operation):
+            """Dummy operation with no QASM spelling or decomposition."""
+
+            num_wires = 1
+
+        tape = qml.tape.QuantumScript([NoDecompOp(wires=0)], [qml.sample()])
+        with pytest.raises(ValueError):
+            to_qasm3(tape)
+
+    def test_decomposition_fallback(self):
+        """Gates outside the QASM gate set decompose to supported ones."""
+        tape = qml.tape.QuantumScript([qml.IsingXX(0.5, wires=[0, 1])], [qml.sample()])
+        qasm = to_qasm3(tape)
+        assert "IsingXX" not in qasm
+        _parse(qasm)
+
+    def test_rotations(self):
+        """Diagonalizing gates are appended when rotations=True."""
+        tape = qml.tape.QuantumScript([qml.Hadamard(0)], [qml.expval(qml.PauliX(0))])
+        qasm = to_qasm3(tape)
+        assert qasm.count("h q[0];") == 2
+        assert to_qasm3(tape, rotations=False).count("h q[0];") == 1
+
+    def test_measure_all_false(self):
+        """measure_all=False only measures the terminally measured wires."""
+        tape = qml.tape.QuantumScript(
+            [qml.Hadamard(0), qml.CNOT(wires=[0, 1])], [qml.sample(wires=1)]
+        )
+        qasm = to_qasm3(tape, measure_all=False)
+        assert "bit[1] c;" in qasm
+        assert "c[0] = measure q[1];" in qasm
+        assert "measure q[0];" not in qasm
+        _parse(qasm)
+
+    def test_precision(self):
+        """The precision argument controls parameter formatting."""
+        tape = qml.tape.QuantumScript([qml.RX(0.123456789, wires=0)], [qml.sample()])
+        qasm = to_qasm3(tape, precision=3)
+        assert "rx(0.123) q[0];" in qasm
+
+    def test_global_phase(self):
+        """GlobalPhase emits a gphase statement with no qubit operands and
+        the opposite sign convention."""
+        tape = qml.tape.QuantumScript(
+            [qml.GlobalPhase(0.5), qml.PauliX(0)], [qml.sample()]
+        )
+        qasm = to_qasm3(tape)
+        assert "gphase(-0.5);" in qasm
+        _parse(qasm)
+
+    def test_empty_circuit(self):
+        """A circuit with no wires serializes to just the header."""
+        tape = qml.tape.QuantumScript([], [])
+        assert to_qasm3(tape) == 'OPENQASM 3.0;\ninclude "stdgates.inc";\n'
+
+    @pytest.mark.parametrize("gate_class", [XX, YY, ZZ])
+    def test_plugin_ising_gates_decompose(self, gate_class):
+        """The plugin's Ising gates serialize via their core-gate decomposition."""
+        tape = qml.tape.QuantumScript(
+            [gate_class(0.5, wires=[0, 1]), _mid_measure(0)], [qml.sample()]
+        )
+        qasm = to_qasm3(tape)
+        assert gate_class.__name__ not in qasm
+        assert "mcms[0] = measure q[0];" in qasm
+        _parse(qasm)
+
+    def test_native_gateset(self):
+        """Native gates serialize directly, in turns, without stdgates.inc."""
+        tape = qml.tape.QuantumScript(
+            [
+                GPI(0.5, wires=0),
+                GPI2(0, wires=1),
+                _mid_measure(0, reset=True),
+                MS(0, 0.5, wires=[0, 1]),
+            ],
+            [qml.sample()],
+        )
+        qasm = to_qasm3(tape, gateset="native")
+        assert "stdgates.inc" not in qasm
+        assert "gpi(0.5) q[0];" in qasm
+        assert "gpi2(0) q[1];" in qasm
+        assert "mcms[0] = measure q[0];" in qasm
+        assert "reset q[0];" in qasm
+        assert "ms(0,0.5,0.25) q[0],q[1];" in qasm
+        _parse(qasm)
+
+    def test_native_gateset_rejects_qis_gate(self):
+        """Abstract gates are not serialized into a native-gateset program."""
+        tape = qml.tape.QuantumScript([qml.Hadamard(0)], [qml.sample()])
+        with pytest.raises(ValueError):
+            to_qasm3(tape, gateset="native")
+
+    def test_operations_to_qasm3(self):
+        """The operations-level serializer emits no terminal measurements."""
+        ops = [qml.Hadamard(0), _mid_measure(0, reset=True), qml.PauliX(0)]
+        qasm = operations_to_qasm3(ops, wires=Wires([0, 1]))
+        expected = "\n".join(
+            [
+                "OPENQASM 3.0;",
+                'include "stdgates.inc";',
+                "qubit[2] q;",
+                "bit[1] mcms;",
+                "h q[0];",
+                "mcms[0] = measure q[0];",
+                "reset q[0];",
+                "x q[0];",
+            ]
+        )
+        assert qasm == expected + "\n"
+        _parse(qasm)
+
+    def test_operations_to_qasm3_custom_wire_labels(self):
+        """Wire labels map to qubit indices by their position in wires."""
+        ops = [qml.Hadamard("b"), _mid_measure("a")]
+        qasm = operations_to_qasm3(ops, wires=Wires(["a", "b"]))
+        assert "h q[1];" in qasm
+        assert "mcms[0] = measure q[0];" in qasm
+        _parse(qasm)
+
+    def test_mcm_qnode_end_to_end(self):
+        """A QNode with measure-and-reuse serializes to a valid program."""
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(0)
+            qml.measure(0, reset=True)
+            qml.CNOT(wires=[0, 1])
+            return qml.sample()
+
+        qasm = to_qasm3(circuit)()
+        expected = "\n".join(
+            [
+                "OPENQASM 3.0;",
+                'include "stdgates.inc";',
+                "qubit[2] q;",
+                "bit[2] c;",
+                "bit[1] mcms;",
+                "h q[0];",
+                "mcms[0] = measure q[0];",
+                "reset q[0];",
+                "cx q[0],q[1];",
+                "c[0] = measure q[0];",
+                "c[1] = measure q[1];",
+            ]
+        )
+        assert qasm == expected + "\n"
+        _parse(qasm)

--- a/tests/test_qasm3.py
+++ b/tests/test_qasm3.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Xanadu Quantum Technologies Inc.
+# Copyright 2018-2026 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,10 +31,6 @@ def _parse(qasm):
     openqasm3.parse(qasm)
 
 
-def _mid_measure(wire, reset=False, postselect=None):
-    return MidMeasureMP(Wires(wire), reset=reset, postselect=postselect)
-
-
 class TestOperationsToQasm3:
     """Tests serializing operation lists to OpenQASM 3.0 programs."""
 
@@ -48,7 +44,7 @@ class TestOperationsToQasm3:
                 'include "stdgates.inc";',
                 "qubit[2] q;",
                 "h q[0];",
-                "cx q[0],q[1];",
+                "cx q[0], q[1];",
             ]
         )
         assert qasm == expected + "\n"
@@ -56,7 +52,7 @@ class TestOperationsToQasm3:
 
     def test_mid_measure(self):
         """Mid-circuit measurements are recorded in the mcms register."""
-        ops = [qp.Hadamard(0), _mid_measure(0), qp.PauliX(1)]
+        ops = [qp.Hadamard(0), MidMeasureMP(Wires(0)), qp.PauliX(1)]
         qasm = operations_to_qasm3(ops, wires=[0, 1])
         assert "bit[1] mcms;" in qasm
         assert "mcms[0] = measure q[0];" in qasm
@@ -66,7 +62,7 @@ class TestOperationsToQasm3:
     def test_mid_measure_reset(self):
         """A mid-circuit measurement with reset emits an explicit reset,
         enabling qubit reuse."""
-        ops = [qp.Hadamard(0), _mid_measure(0, reset=True), qp.PauliX(0)]
+        ops = [qp.Hadamard(0), MidMeasureMP(Wires(0), reset=True), qp.PauliX(0)]
         qasm = operations_to_qasm3(ops, wires=[0, 1])
         expected = "\n".join(
             [
@@ -88,19 +84,30 @@ class TestOperationsToQasm3:
         circuit order."""
         ops = [
             qp.Hadamard(0),
-            _mid_measure(0, reset=True),
+            MidMeasureMP(Wires(0), reset=True),
             qp.CNOT(wires=[0, 1]),
-            _mid_measure(1),
+            MidMeasureMP(Wires(1)),
         ]
         qasm = operations_to_qasm3(ops, wires=[0, 1])
-        assert "bit[2] mcms;" in qasm
-        assert "mcms[0] = measure q[0];" in qasm
-        assert "mcms[1] = measure q[1];" in qasm
+        expected = "\n".join(
+            [
+                "OPENQASM 3.0;",
+                'include "stdgates.inc";',
+                "qubit[2] q;",
+                "bit[2] mcms;",
+                "h q[0];",
+                "mcms[0] = measure q[0];",
+                "reset q[0];",
+                "cx q[0], q[1];",
+                "mcms[1] = measure q[1];",
+            ]
+        )
+        assert qasm == expected + "\n"
         _parse(qasm)
 
     def test_postselect_raises(self):
         """Postselecting mid-circuit measurements are not supported."""
-        ops = [qp.Hadamard(0), _mid_measure(0, postselect=0)]
+        ops = [qp.Hadamard(0), MidMeasureMP(Wires(0), postselect=0)]
         with pytest.raises(NotImplementedError, match="postselection"):
             operations_to_qasm3(ops, wires=[0])
 
@@ -145,7 +152,7 @@ class TestOperationsToQasm3:
     @pytest.mark.parametrize("gate_class", [XX, YY, ZZ])
     def test_plugin_ising_gates_decompose(self, gate_class):
         """The plugin's Ising gates serialize via their core-gate decomposition."""
-        ops = [gate_class(0.5, wires=[0, 1]), _mid_measure(0)]
+        ops = [gate_class(0.5, wires=[0, 1]), MidMeasureMP(Wires(0))]
         qasm = operations_to_qasm3(ops, wires=[0, 1])
         assert gate_class.__name__ not in qasm
         assert "mcms[0] = measure q[0];" in qasm
@@ -156,7 +163,7 @@ class TestOperationsToQasm3:
         ops = [
             GPI(0.5, wires=0),
             GPI2(0, wires=1),
-            _mid_measure(0, reset=True),
+            MidMeasureMP(Wires(0), reset=True),
             MS(0, 0.5, wires=[0, 1]),
         ]
         qasm = operations_to_qasm3(ops, wires=[0, 1], gateset="native")
@@ -165,7 +172,7 @@ class TestOperationsToQasm3:
         assert "gpi2(0) q[1];" in qasm
         assert "mcms[0] = measure q[0];" in qasm
         assert "reset q[0];" in qasm
-        assert "ms(0,0.5,0.25) q[0],q[1];" in qasm
+        assert "ms(0,0.5,0.25) q[0], q[1];" in qasm
         _parse(qasm)
 
     def test_native_gateset_rejects_qis_gate(self):
@@ -175,7 +182,7 @@ class TestOperationsToQasm3:
 
     def test_custom_wire_labels(self):
         """Wire labels map to qubit indices by their position in wires."""
-        ops = [qp.Hadamard("b"), _mid_measure("a")]
+        ops = [qp.Hadamard("b"), MidMeasureMP(Wires("a"))]
         qasm = operations_to_qasm3(ops, wires=["a", "b"])
         assert "h q[1];" in qasm
         assert "mcms[0] = measure q[0];" in qasm

--- a/tests/test_qasm3.py
+++ b/tests/test_qasm3.py
@@ -16,7 +16,7 @@ Tests for the to_qasm3 serializer.
 """
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane.measurements import MidMeasureMP
 from pennylane.wires import Wires
 
@@ -41,8 +41,8 @@ class TestToQasm3:
     def test_basic_circuit(self):
         """A plain circuit serializes with header, registers, gates, and
         terminal measurements on all wires."""
-        tape = qml.tape.QuantumScript(
-            [qml.Hadamard(0), qml.CNOT(wires=[0, 1])], [qml.sample()]
+        tape = qp.tape.QuantumScript(
+            [qp.Hadamard(0), qp.CNOT(wires=[0, 1])], [qp.sample()]
         )
         qasm = to_qasm3(tape)
         expected = "\n".join(
@@ -62,13 +62,13 @@ class TestToQasm3:
 
     def test_qnode_input(self):
         """A QNode input returns a wrapper that accepts the QNode arguments."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(theta):
-            qml.RX(theta, wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.sample()
+            qp.RX(theta, wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.sample()
 
         qasm = to_qasm3(circuit)(0.5)
         assert "rx(0.5) q[0];" in qasm
@@ -76,8 +76,8 @@ class TestToQasm3:
 
     def test_mid_measure(self):
         """Mid-circuit measurements are recorded in the mcms register."""
-        tape = qml.tape.QuantumScript(
-            [qml.Hadamard(0), _mid_measure(0), qml.PauliX(1)], [qml.sample()]
+        tape = qp.tape.QuantumScript(
+            [qp.Hadamard(0), _mid_measure(0), qp.PauliX(1)], [qp.sample()]
         )
         qasm = to_qasm3(tape)
         assert "bit[1] mcms;" in qasm
@@ -88,9 +88,9 @@ class TestToQasm3:
     def test_mid_measure_reset(self):
         """A mid-circuit measurement with reset emits an explicit reset,
         enabling qubit reuse."""
-        tape = qml.tape.QuantumScript(
-            [qml.Hadamard(0), _mid_measure(0, reset=True), qml.PauliX(0)],
-            [qml.sample()],
+        tape = qp.tape.QuantumScript(
+            [qp.Hadamard(0), _mid_measure(0, reset=True), qp.PauliX(0)],
+            [qp.sample()],
         )
         qasm = to_qasm3(tape)
         lines = qasm.splitlines()
@@ -102,14 +102,14 @@ class TestToQasm3:
     def test_multiple_mid_measures(self):
         """Multiple mid-circuit measurements get consecutive mcms bits in
         circuit order."""
-        tape = qml.tape.QuantumScript(
+        tape = qp.tape.QuantumScript(
             [
-                qml.Hadamard(0),
+                qp.Hadamard(0),
                 _mid_measure(0, reset=True),
-                qml.CNOT(wires=[0, 1]),
+                qp.CNOT(wires=[0, 1]),
                 _mid_measure(1),
             ],
-            [qml.sample()],
+            [qp.sample()],
         )
         qasm = to_qasm3(tape)
         assert "bit[2] mcms;" in qasm
@@ -119,52 +119,52 @@ class TestToQasm3:
 
     def test_postselect_raises(self):
         """Postselecting mid-circuit measurements are not supported."""
-        tape = qml.tape.QuantumScript(
-            [qml.Hadamard(0), _mid_measure(0, postselect=0)], [qml.sample()]
+        tape = qp.tape.QuantumScript(
+            [qp.Hadamard(0), _mid_measure(0, postselect=0)], [qp.sample()]
         )
         with pytest.raises(NotImplementedError, match="postselection"):
             to_qasm3(tape)
 
     def test_conditional_raises(self):
-        """Classically controlled operations (qml.cond) are out of scope."""
-        with qml.tape.QuantumTape() as tape:
-            qml.Hadamard(0)
-            m = qml.measure(0)
-            qml.cond(m, qml.PauliX)(0)
-            qml.sample()
+        """Classically controlled operations (qp.cond) are out of scope."""
+        with qp.tape.QuantumTape() as tape:
+            qp.Hadamard(0)
+            m = qp.measure(0)
+            qp.cond(m, qp.PauliX)(0)
+            qp.sample()
         with pytest.raises(ValueError):
             to_qasm3(tape)
 
     def test_unsupported_gate_raises(self):
         """A gate with no QASM spelling and no decomposition raises."""
 
-        class NoDecompOp(qml.operation.Operation):
+        class NoDecompOp(qp.operation.Operation):
             """Dummy operation with no QASM spelling or decomposition."""
 
             num_wires = 1
 
-        tape = qml.tape.QuantumScript([NoDecompOp(wires=0)], [qml.sample()])
+        tape = qp.tape.QuantumScript([NoDecompOp(wires=0)], [qp.sample()])
         with pytest.raises(ValueError):
             to_qasm3(tape)
 
     def test_decomposition_fallback(self):
         """Gates outside the QASM gate set decompose to supported ones."""
-        tape = qml.tape.QuantumScript([qml.IsingXX(0.5, wires=[0, 1])], [qml.sample()])
+        tape = qp.tape.QuantumScript([qp.IsingXX(0.5, wires=[0, 1])], [qp.sample()])
         qasm = to_qasm3(tape)
         assert "IsingXX" not in qasm
         _parse(qasm)
 
     def test_rotations(self):
         """Diagonalizing gates are appended when rotations=True."""
-        tape = qml.tape.QuantumScript([qml.Hadamard(0)], [qml.expval(qml.PauliX(0))])
+        tape = qp.tape.QuantumScript([qp.Hadamard(0)], [qp.expval(qp.PauliX(0))])
         qasm = to_qasm3(tape)
         assert qasm.count("h q[0];") == 2
         assert to_qasm3(tape, rotations=False).count("h q[0];") == 1
 
     def test_measure_all_false(self):
         """measure_all=False only measures the terminally measured wires."""
-        tape = qml.tape.QuantumScript(
-            [qml.Hadamard(0), qml.CNOT(wires=[0, 1])], [qml.sample(wires=1)]
+        tape = qp.tape.QuantumScript(
+            [qp.Hadamard(0), qp.CNOT(wires=[0, 1])], [qp.sample(wires=1)]
         )
         qasm = to_qasm3(tape, measure_all=False)
         assert "bit[1] c;" in qasm
@@ -174,15 +174,15 @@ class TestToQasm3:
 
     def test_precision(self):
         """The precision argument controls parameter formatting."""
-        tape = qml.tape.QuantumScript([qml.RX(0.123456789, wires=0)], [qml.sample()])
+        tape = qp.tape.QuantumScript([qp.RX(0.123456789, wires=0)], [qp.sample()])
         qasm = to_qasm3(tape, precision=3)
         assert "rx(0.123) q[0];" in qasm
 
     def test_global_phase(self):
         """GlobalPhase emits a gphase statement with no qubit operands and
         the opposite sign convention."""
-        tape = qml.tape.QuantumScript(
-            [qml.GlobalPhase(0.5), qml.PauliX(0)], [qml.sample()]
+        tape = qp.tape.QuantumScript(
+            [qp.GlobalPhase(0.5), qp.PauliX(0)], [qp.sample()]
         )
         qasm = to_qasm3(tape)
         assert "gphase(-0.5);" in qasm
@@ -190,14 +190,14 @@ class TestToQasm3:
 
     def test_empty_circuit(self):
         """A circuit with no wires serializes to just the header."""
-        tape = qml.tape.QuantumScript([], [])
+        tape = qp.tape.QuantumScript([], [])
         assert to_qasm3(tape) == 'OPENQASM 3.0;\ninclude "stdgates.inc";\n'
 
     @pytest.mark.parametrize("gate_class", [XX, YY, ZZ])
     def test_plugin_ising_gates_decompose(self, gate_class):
         """The plugin's Ising gates serialize via their core-gate decomposition."""
-        tape = qml.tape.QuantumScript(
-            [gate_class(0.5, wires=[0, 1]), _mid_measure(0)], [qml.sample()]
+        tape = qp.tape.QuantumScript(
+            [gate_class(0.5, wires=[0, 1]), _mid_measure(0)], [qp.sample()]
         )
         qasm = to_qasm3(tape)
         assert gate_class.__name__ not in qasm
@@ -206,14 +206,14 @@ class TestToQasm3:
 
     def test_native_gateset(self):
         """Native gates serialize directly, in turns, without stdgates.inc."""
-        tape = qml.tape.QuantumScript(
+        tape = qp.tape.QuantumScript(
             [
                 GPI(0.5, wires=0),
                 GPI2(0, wires=1),
                 _mid_measure(0, reset=True),
                 MS(0, 0.5, wires=[0, 1]),
             ],
-            [qml.sample()],
+            [qp.sample()],
         )
         qasm = to_qasm3(tape, gateset="native")
         assert "stdgates.inc" not in qasm
@@ -226,13 +226,13 @@ class TestToQasm3:
 
     def test_native_gateset_rejects_qis_gate(self):
         """Abstract gates are not serialized into a native-gateset program."""
-        tape = qml.tape.QuantumScript([qml.Hadamard(0)], [qml.sample()])
+        tape = qp.tape.QuantumScript([qp.Hadamard(0)], [qp.sample()])
         with pytest.raises(ValueError):
             to_qasm3(tape, gateset="native")
 
     def test_operations_to_qasm3(self):
         """The operations-level serializer emits no terminal measurements."""
-        ops = [qml.Hadamard(0), _mid_measure(0, reset=True), qml.PauliX(0)]
+        ops = [qp.Hadamard(0), _mid_measure(0, reset=True), qp.PauliX(0)]
         qasm = operations_to_qasm3(ops, wires=Wires([0, 1]))
         expected = "\n".join(
             [
@@ -251,7 +251,7 @@ class TestToQasm3:
 
     def test_operations_to_qasm3_custom_wire_labels(self):
         """Wire labels map to qubit indices by their position in wires."""
-        ops = [qml.Hadamard("b"), _mid_measure("a")]
+        ops = [qp.Hadamard("b"), _mid_measure("a")]
         qasm = operations_to_qasm3(ops, wires=Wires(["a", "b"]))
         assert "h q[1];" in qasm
         assert "mcms[0] = measure q[0];" in qasm
@@ -259,14 +259,14 @@ class TestToQasm3:
 
     def test_mcm_qnode_end_to_end(self):
         """A QNode with measure-and-reuse serializes to a valid program."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.Hadamard(0)
-            qml.measure(0, reset=True)
-            qml.CNOT(wires=[0, 1])
-            return qml.sample()
+            qp.Hadamard(0)
+            qp.measure(0, reset=True)
+            qp.CNOT(wires=[0, 1])
+            return qp.sample()
 
         qasm = to_qasm3(circuit)()
         expected = "\n".join(


### PR DESCRIPTION
**Context**

Some IonQ hardware and simulators will support mid-circuit measurements (MCMs) and qubit reset, but the PennyLane-IonQ plugin can only submit flat `ionq.circuit.v1` gate lists., which cannot express them. Circuits using `qp.measure` therefore fail on IonQ devices  atm.

**Solution**

Route circuits containing MCMs through IonQ's `ionq.qasm3.v1` job type:

- Added new `pennylane_ionq/qasm3.py` module with an `operations_to_qasm3` serializer that converts an operation list (including `MidMeasureMP` along reset) into an OpenQASM 3.0 program, for both the qis and native gatesets. Gates outside the target gateset are decomposed.
- IonQDevice detects MCM circuits via a new `circuit_requires_qasm3` check and submits them as a QASM 3 job (`_apply_qasm3`), pinning the v0.4 compiler stack so results come back register-named. All other circuits keep the existing `ionq.circuit.v1` path unchanged.
- The device stopping_condition accepts MidMeasureMP so MCMs reach the device intact; the plugin's XX/YY/ZZ gates gained decompositions to the core Ising gates so they serialize cleanly.

**Limitations**

- `qp.cond` is rejected with an error pointing to `qp.defer_measurements` / `mcm_method="deferred"`;
- Postselection is not supported (`NotImplementedError`);
- MCM circuits must be submitted one at a time (no batching).

**Docs & tests**

Added a "Mid-circuit measurements and qubit reset" section to `doc/devices.rst`, a changelog entry, a dedicated `tests/test_qasm3.py` suite (validated against the reference openqasm3 parser), and device-level tests for routing, payload shape, and error cases.