### PR TITLE
feat: Add memory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features since last release
 
-* Added a ``memory`` device keyword argument. When set to ``True``, the per-shot
+* Added a ``memory`` device keyword argument. When set to ``True``, the shotwise
   measurement outcomes returned by the API are used as the device samples, instead
   of generating samples locally from the returned probabilities. Available for QPU
   and noisy-simulator jobs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   measurement outcomes returned by the API are used as the device samples, instead
   of generating samples locally from the returned probabilities. Available for QPU
   and noisy-simulator jobs.
-  [(#190)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/190)
+  [(#195)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/195)
 
 ### Improvements 🛠
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### New features since last release
 
+* Added a ``memory`` device keyword argument. When set to ``True``, the per-shot
+  measurement outcomes returned by the API are used as the device samples, instead
+  of generating samples locally from the returned probabilities. Available for QPU
+  and noisy-simulator jobs.
+  [(#190)](https://github.com/PennyLaneAI/PennyLane-IonQ/pull/190)
+
 ### Improvements 🛠
 
 * Updated tests to stop using deprecated shots kwarg on the device.

--- a/pennylane_ionq/api_client.py
+++ b/pennylane_ionq/api_client.py
@@ -137,14 +137,20 @@ class APIClient:  # pylint: disable=too-many-instance-attributes
         max_retries (int): Maximum number of retries for retriable HTTP errors (default: 3)
         retry_delay (float): Base delay in seconds between retries. Every subsequent k-th retry
             will be delayed by ``retry_delay * (2 ** k)`` (default: 0.5)
+
+    The API hostname can be overridden with the ``IONQ_API_HOSTNAME`` environment
+    variable.
     """
 
     USER_AGENT = "pennylane-ionq-api-client/0.4"
-    HOSTNAME = "api.ionq.co/v0.4"
-    BASE_URL = f"https://{HOSTNAME}"
+    DEFAULT_HOSTNAME = "api.ionq.co/v0.4"
     DEFAULT_TIMEOUT = 600
 
     def __init__(self, **kwargs):
+        # IONQ_API_HOSTNAME allows targeting a different API host
+        self.HOSTNAME = os.getenv("IONQ_API_HOSTNAME", self.DEFAULT_HOSTNAME)
+        self.BASE_URL = f"https://{self.HOSTNAME}"
+
         self.AUTHENTICATION_TOKEN = (
             kwargs.get("api_key", None)
             or os.getenv("PENNYLANE_IONQ_API_KEY")

--- a/pennylane_ionq/api_client.py
+++ b/pennylane_ionq/api_client.py
@@ -80,11 +80,13 @@ RETRIABLE_STATUS_CODES = (
 # 409 Conflict is retriable only for GET requests (Cloudflare DNS resolution errors).
 RETRIABLE_FOR_GET = (409,)
 
+
 class ResultsTypes(str, Enum):
     """Supported results types."""
 
     SHOTS = "shots"
     PROBS = "probabilities"
+
 
 def join_path(base_path, path):
     """

--- a/pennylane_ionq/api_client.py
+++ b/pennylane_ionq/api_client.py
@@ -60,6 +60,7 @@ import json
 import warnings
 import os
 import time
+from enum import Enum
 
 import dateutil.parser
 
@@ -79,6 +80,11 @@ RETRIABLE_STATUS_CODES = (
 # 409 Conflict is retriable only for GET requests (Cloudflare DNS resolution errors).
 RETRIABLE_FOR_GET = (409,)
 
+class ResultsTypes(str, Enum):
+    """Supported results types."""
+
+    SHOTS = "shots"
+    PROBS = "probabilities"
 
 def join_path(base_path, path):
     """
@@ -332,7 +338,7 @@ class ResourceManager:
         """
         return join_path(self.resource.PATH, path)
 
-    def get(self, resource_id=None, params=None):
+    def get(self, resource_id=None, params=None, results_type=ResultsTypes.PROBS):
         """
         Attempts to retrieve a particular record by sending a GET
         request to the appropriate endpoint. If successful, the resource
@@ -350,7 +356,7 @@ class ResourceManager:
             response = self.client.get(self.resource.PATH, params=params)
 
         # we need params later, unfortuantely
-        self.handle_response(response, params)
+        self.handle_response(response, params, results_type=results_type)
 
     def create(self, **params):
         """
@@ -370,7 +376,7 @@ class ResourceManager:
 
         self.handle_response(response)
 
-    def handle_response(self, response, params=None):
+    def handle_response(self, response, params=None, results_type=ResultsTypes.PROBS):
         """
         Store the status code on the manager object and handle the response
         based on the status code.
@@ -383,7 +389,7 @@ class ResourceManager:
 
             if response.status_code in (200, 201):
                 self.http_response_data = response.json()
-                self.handle_success_response(response, params=params)
+                self.handle_success_response(response, params=params, results_type=results_type)
             else:
                 try:
                     self.http_response_data = response.json()
@@ -399,14 +405,14 @@ class ResourceManager:
         """
         warnings.warn("Your request could not be completed")
 
-    def handle_success_response(self, response, params=None):
+    def handle_success_response(self, response, params=None, results_type=ResultsTypes.PROBS):
         """
         Handles a successful response by refreshing the instance fields.
 
         Args:
             response (requests.Response): a response object to be parsed
         """
-        self.refresh_data(response.json(), params=params)
+        self.refresh_data(response.json(), params=params, results_type=results_type)
 
     def handle_error_response(self, response):
         """
@@ -427,7 +433,7 @@ class ResourceManager:
         except Exception as e:
             raise Exception(response.text) from e
 
-    def refresh_data(self, data, params=None):
+    def refresh_data(self, data, params=None, results_type=ResultsTypes.PROBS):
         """
         Refreshes the instance's attributes with the provided data and
         converts it to the correct type.
@@ -439,9 +445,16 @@ class ResourceManager:
             field.set(data.get(field.name, None))
 
         results = data.get("results") or {}
-        probabilities = results.get("probabilities") or {}
-        url = probabilities.get("url")
-        if isinstance(url, str) and url:
+        url = None
+        if results_type == ResultsTypes.PROBS:
+            probabilities = results.get("probabilities") or {}
+            url = probabilities.get("url")
+
+        elif results_type == ResultsTypes.SHOTS:
+            shotwise_outputs = results.get("shots") or {}
+            url = shotwise_outputs.get("url")
+
+        if url and isinstance(url, str):
             resp = self.client.get(self.join_path(url), params=params)
             self.resource.fields[-1].set(resp.json())
 

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -641,7 +641,9 @@ class IonQDevice(QubitDevice):
         params = {} if self.sharpen is None else {"sharpen": self.sharpen}
 
         if not self.memory or (self.target == "simulator" and self.noise_model in (None, "ideal")):
-            job.manager.get(resource_id=job.id.value, params=params, results_type=ResultsTypes.PROBS)
+            job.manager.get(
+                resource_id=job.id.value, params=params, results_type=ResultsTypes.PROBS
+            )
 
             # The returned job histogram is of the form
             # dict[str, float], and maps the computational basis
@@ -663,11 +665,15 @@ class IonQDevice(QubitDevice):
                 # advertises its own per-shot results URL.
                 memory_results = []
                 for child_id in child_ids:
-                    job.manager.get(resource_id=child_id, params=params, results_type=ResultsTypes.SHOTS)
+                    job.manager.get(
+                        resource_id=child_id, params=params, results_type=ResultsTypes.SHOTS
+                    )
                     memory_results.append(self._shots_to_samples(job.data.value))
                 self.memory_results = memory_results
             else:
-                job.manager.get(resource_id=job.id.value, params=params, results_type=ResultsTypes.SHOTS)
+                job.manager.get(
+                    resource_id=job.id.value, params=params, results_type=ResultsTypes.SHOTS
+                )
                 self.memory_results = [self._shots_to_samples(job.data.value)]
 
     def _shots_to_samples(self, raw_shots):

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -687,21 +687,6 @@ class IonQDevice(QubitDevice):
         basis_states = np.fromiter((int(s) for s in raw_shots), dtype=np.int64)
         return QubitDevice.states_to_binary(basis_states, self.num_wires)[:, ::-1]
 
-    def _memory_samples(self):
-        """Return the per-shot samples retrieved from the API for the current circuit.
-
-        Returns:
-            array[int] or None: binary samples of shape ``(shots, num_wires)``, or
-            ``None`` if per-shot results are not available.
-        """
-        if self.memory_results is None:
-            return None
-
-        if self._current_circuit_index is None and len(self.memory_results) > 1:
-            raise CircuitIndexNotSetException()
-
-        return self.memory_results[self._current_circuit_index or 0]
-
     @property
     def prob(self):
         """None or array[float]: Array of computational basis state probabilities. If
@@ -826,9 +811,10 @@ class SimulatorDevice(IonQDevice):
     def generate_samples(self):
         """Generates samples from the per-shot results if available, otherwise by
         random sampling with the probabilities returned by the simulator."""
-        memory_samples = self._memory_samples()
-        if memory_samples is not None:
-            return memory_samples
+        if self.memory_results is not None:
+            if self._current_circuit_index is None and len(self.memory_results) > 1:
+                raise CircuitIndexNotSetException()
+            return self.memory_results[self._current_circuit_index or 0]
 
         number_of_states = 2**self.num_wires
         samples = self.sample_basis_states(number_of_states, self.prob)
@@ -932,9 +918,10 @@ class QPUDevice(IonQDevice):
         which the experiments were done, but is instead controlled by a random
         shuffle (and hence set by numpy random seed).
         """
-        memory_samples = self._memory_samples()
-        if memory_samples is not None:
-            return memory_samples
+        if self.memory_results is not None:
+            if self._current_circuit_index is None and len(self.memory_results) > 1:
+                raise CircuitIndexNotSetException()
+            return self.memory_results[self._current_circuit_index or 0]
 
         number_of_states = 2**self.num_wires
         counts = np.rint(

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -131,9 +131,9 @@ class IonQDevice(QubitDevice):
         noise_seed (int): seed for the noise model random number generator, for reproducible noisy
             simulation results. Must be an integer between 1 and 2\ :sup:`31` - 1. Only used when ``noise_model`` is set.
             Defaults to None (random seed).
-        memory (bool): if True, use the per-shot measurement outcomes returned by the API as the
+        memory (bool): if True, use the shotwise measurement outcomes returned by the API as the
             device samples, instead of generating samples locally from the returned probabilities.
-            Per-shot results are not available for ideal simulation. Defaults to False.
+            Shotwise results are not available for ideal simulation. Defaults to False.
         dry_run (bool): If True, the job will be submitted by the API client but not processed remotely.
             Useful for obtaining cost estimates. Defaults to False.
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
@@ -210,11 +210,9 @@ class IonQDevice(QubitDevice):
                 raise ValueError(
                     f"noise_seed must be an integer between 1 and 2^31 - 1, got {noise_seed}."
                 )
-        if not isinstance(memory, bool):
-            raise ValueError(f"memory must be a boolean, got {memory}.")
         if memory and target == "simulator" and noise_model in (None, "ideal"):
             warnings.warn(
-                "Per-shot results are not available for ideal simulation; samples "
+                "Shotwise results are not available for ideal simulation; samples "
                 "will be generated from the returned probabilities.",
                 UserWarning,
             )
@@ -662,7 +660,7 @@ class IonQDevice(QubitDevice):
                 child_ids = list(job.data.value.keys())
 
                 # The parent job only carries aggregated probabilities; each child job
-                # advertises its own per-shot results URL.
+                # advertises its own shotwise results URL.
                 memory_results = []
                 for child_id in child_ids:
                     job.manager.get(
@@ -677,7 +675,7 @@ class IonQDevice(QubitDevice):
                 self.memory_results = [self._shots_to_samples(job.data.value)]
 
     def _shots_to_samples(self, raw_shots):
-        """Convert IonQ API per-shot results into PennyLane binary samples.
+        """Convert IonQ API shotwise results into PennyLane binary samples.
 
         The API encodes each shot as a basis-state integer using little-endian
         ordering, like the histogram keys. ``states_to_binary`` places the least
@@ -763,9 +761,9 @@ class SimulatorDevice(IonQDevice):
         noise_seed (int): seed for the noise model random number generator, for reproducible noisy
             simulation results. Must be an integer between 1 and 2\ :sup:`31` - 1. Only used when ``noise_model`` is set.
             Defaults to None (random seed).
-        memory (bool): if True, use the per-shot measurement outcomes returned by the API as the
+        memory (bool): if True, use the shotwise measurement outcomes returned by the API as the
             device samples, instead of generating samples locally from the returned probabilities.
-            Per-shot results are not available for ideal simulation. Defaults to False.
+            Shotwise results are not available for ideal simulation. Defaults to False.
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
         timeout (float): Request timeout in seconds. Defaults to None, which uses the
             ``APIClient`` default.
@@ -815,7 +813,7 @@ class SimulatorDevice(IonQDevice):
         )
 
     def generate_samples(self):
-        """Generates samples from the per-shot results if available, otherwise by
+        """Generates samples from the shotwise results if available, otherwise by
         random sampling with the probabilities returned by the simulator."""
         if self.memory_results is not None:
             if self._current_circuit_index is None and len(self.memory_results) > 1:
@@ -857,7 +855,7 @@ class QPUDevice(IonQDevice):
             Defaults to None (no value passed at job retrieval). Will generally return more accurate results if
             your expected output distribution has peaks. See `IonQ Debiasing and Sharpening
             <https://ionq.com/resources/debiasing-and-sharpening>`_ for details.
-        memory (bool): if True, use the per-shot measurement outcomes returned by the API as the
+        memory (bool): if True, use the shotwise measurement outcomes returned by the API as the
             device samples, instead of generating samples locally from the returned probabilities.
             Defaults to False.
         dry_run (bool): whether to run the job in dry run mode. Defaults to False.
@@ -918,7 +916,7 @@ class QPUDevice(IonQDevice):
     def generate_samples(self):
         """Generates samples from the qpu.
 
-        If per-shot results were retrieved from the API, they are returned in the
+        If shotwise results were retrieved from the API, they are returned in the
         order the shots were measured. Otherwise, samples are generated from the
         returned probabilities, and their order is not indicative of the order in
         which the experiments were done, but is instead controlled by a random

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -668,9 +668,7 @@ class IonQDevice(QubitDevice):
 
             memory_results = []
             for job_id in job_ids:
-                job.manager.get(
-                    resource_id=job_id, params=params, results_type=ResultsTypes.SHOTS
-                )
+                job.manager.get(resource_id=job_id, params=params, results_type=ResultsTypes.SHOTS)
                 memory_results.append(self._shotwise_to_samples(job.data.value))
             self.memory_results = memory_results
 

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -656,25 +656,25 @@ class IonQDevice(QubitDevice):
         else:
             # Shotwise outputs using memory
             if self.job.get("type") == "ionq.multi-circuit.v1":
-                # Multi-circuit job histograms are keyed by child job ID.
-                child_ids = list(job.data.value.keys())
-
-                # The parent job only carries aggregated probabilities; each child job
-                # advertises its own shotwise results URL.
-                memory_results = []
-                for child_id in child_ids:
-                    job.manager.get(
-                        resource_id=child_id, params=params, results_type=ResultsTypes.SHOTS
-                    )
-                    memory_results.append(self._shots_to_samples(job.data.value))
-                self.memory_results = memory_results
+                # Multi-circuit job shots:
+                # ------------------------
+                # Parent job only carries aggregated probabilities;
+                # Results are keyed by child job ID. Each child job advertises
+                # its own shotwise results URL so store these IDs.
+                child_ids = job.data.value.keys()
+                job_ids = list(child_ids)
             else:
-                job.manager.get(
-                    resource_id=job.id.value, params=params, results_type=ResultsTypes.SHOTS
-                )
-                self.memory_results = [self._shots_to_samples(job.data.value)]
+                job_ids = [job.id.value]
 
-    def _shots_to_samples(self, raw_shots):
+            memory_results = []
+            for job_id in job_ids:
+                job.manager.get(
+                    resource_id=job_id, params=params, results_type=ResultsTypes.SHOTS
+                )
+                memory_results.append(self._shotwise_to_samples(job.data.value))
+            self.memory_results = memory_results
+
+    def _shotwise_to_samples(self, raw_shots):
         """Convert IonQ API shotwise results into PennyLane binary samples.
 
         The API encodes each shot as a basis-state integer using little-endian

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -33,7 +33,7 @@ from pennylane.ops.op_math.prod import Prod
 
 from pennylane.ops.op_math.linear_combination import LinearCombination
 
-from .api_client import Job, JobExecutionError
+from .api_client import Job, JobExecutionError, ResultsTypes
 from .exceptions import (
     CircuitIndexNotSetException,
     ComplexEvolutionCoefficientsNotSupported,
@@ -640,101 +640,52 @@ class IonQDevice(QubitDevice):
 
         params = {} if self.sharpen is None else {"sharpen": self.sharpen}
 
-        job.manager.get(resource_id=job.id.value, params=params)
+        if not self.memory or (self.target == "simulator" and self.noise_model in (None, "ideal")):
+            job.manager.get(resource_id=job.id.value, params=params, results_type=ResultsTypes.PROBS)
 
-        # The returned job histogram is of the form
-        # dict[str, float], and maps the computational basis
-        # state (as a base-10 integer string) to the probability
-        # as a floating point value between 0 and 1.
-        # e.g., {"0": 0.413, "9": 0.111, "17": 0.476}
-        # Multi-circuit job histograms are keyed by child job ID.
-        some_inner_value = next(iter(job.data.value.values()))
-        if isinstance(some_inner_value, dict):
-            child_ids = list(job.data.value.keys())
-            self.histograms = list(job.data.value.values())
+            # The returned job histogram is of the form
+            # dict[str, float], and maps the computational basis
+            # state (as a base-10 integer string) to the probability
+            # as a floating point value between 0 and 1.
+            # e.g., {"0": 0.413, "9": 0.111, "17": 0.476}
+            some_inner_value = next(iter(job.data.value.values()))
+            if isinstance(some_inner_value, dict):
+                self.histograms = list(job.data.value.values())
+            else:
+                self.histograms = [job.data.value]
         else:
-            child_ids = None
-            self.histograms = [job.data.value]
+            # Shotwise outputs using memory
+            if self.job.get("type") == "ionq.multi-circuit.v1":
+                # Multi-circuit job histograms are keyed by child job ID.
+                child_ids = list(job.data.value.keys())
 
-        if self.memory and not (self.target == "simulator" and self.noise_model in (None, "ideal")):
-            self.memory_results = self._fetch_memory_results(job, child_ids)
+                # The parent job only carries aggregated probabilities; each child job
+                # advertises its own per-shot results URL.
+                memory_results = []
+                for child_id in child_ids:
+                    job.manager.get(resource_id=child_id, params=params, results_type=ResultsTypes.SHOTS)
+                    memory_results.append(self._shots_to_samples(job.data.value))
+                self.memory_results = memory_results
+            else:
+                job.manager.get(resource_id=job.id.value, params=params, results_type=ResultsTypes.SHOTS)
+                self.memory_results = [self._shots_to_samples(job.data.value)]
 
-    def _fetch_memory_results(self, job, child_ids=None):
-        """Fetch per-shot measurement outcomes for each circuit of a completed job.
+    def _shots_to_samples(self, raw_shots):
+        """Convert IonQ API per-shot results into PennyLane binary samples.
 
-        Args:
-            job (Job): the completed job resource.
-            child_ids (list[str] | None): child job IDs of a multi-circuit job,
-                ordered as in ``self.histograms``.
-
-        Returns:
-            list[array[int] or None]: one array of basis-state integers per circuit,
-            with ``None`` entries where per-shot results could not be retrieved.
-        """
-        manager = job.manager
-        if not child_ids:
-            results = (manager.http_response_data or {}).get("results") or {}
-            return [self._fetch_shots((results.get("shots") or {}).get("url"), manager)]
-
-        # The parent job only carries aggregated probabilities; each child job
-        # advertises its own per-shot results URL.
-        memory_results = []
-        for child_id in child_ids:
-            try:
-                response = manager.client.get(manager.join_path(str(child_id)))
-                response.raise_for_status()
-                results = response.json().get("results") or {}
-            except requests.exceptions.RequestException as e:
-                warnings.warn(
-                    f"Failed to retrieve per-shot results for job {child_id}: {e}. "
-                    "Samples for this circuit will be generated from the returned "
-                    "probabilities.",
-                    UserWarning,
-                )
-                memory_results.append(None)
-                continue
-            memory_results.append(
-                self._fetch_shots((results.get("shots") or {}).get("url"), manager)
-            )
-        return memory_results
-
-    def _fetch_shots(self, url, manager):
-        """Fetch a job's per-shot results and convert them to basis-state integers.
+        The API encodes each shot as a basis-state integer using little-endian
+        ordering, like the histogram keys. ``states_to_binary`` places the least
+        significant bit last, so reversing the bit axis yields rows in the
+        big-endian wire ordering expected by PennyLane.
 
         Args:
-            url (str | None): the job's ``results.shots.url``, if any.
-            manager (ResourceManager): the manager used for API requests.
+            raw_shots (list[str]): one little-endian basis-state integer per shot.
 
         Returns:
-            array[int] or None: one big-endian basis-state integer per shot, or
-            ``None`` if the per-shot results could not be retrieved.
+            array[int]: binary samples of shape ``(shots, num_wires)``.
         """
-        if not url:
-            warnings.warn(
-                "The job did not report per-shot results; samples will be "
-                "generated from the returned probabilities.",
-                UserWarning,
-            )
-            return None
-        try:
-            response = manager.client.get(manager.join_path(url))
-            response.raise_for_status()
-            raw_shots = response.json()
-        except requests.exceptions.RequestException as e:
-            warnings.warn(
-                f"Failed to retrieve per-shot results: {e}. Samples will be "
-                "generated from the returned probabilities.",
-                UserWarning,
-            )
-            return None
-
-        # The API returns one decimal-encoded basis state per shot, in
-        # little-endian ordering like the histogram keys; rearrange to the
-        # big-endian ordering expected by PennyLane.
-        return np.fromiter(
-            (int(bin(int(s))[2:].rjust(self.num_wires, "0")[::-1], 2) for s in raw_shots),
-            dtype=np.int64,
-        )
+        basis_states = np.fromiter((int(s) for s in raw_shots), dtype=np.int64)
+        return QubitDevice.states_to_binary(basis_states, self.num_wires)[:, ::-1]
 
     def _memory_samples(self):
         """Return the per-shot samples retrieved from the API for the current circuit.
@@ -749,10 +700,7 @@ class IonQDevice(QubitDevice):
         if self._current_circuit_index is None and len(self.memory_results) > 1:
             raise CircuitIndexNotSetException()
 
-        basis_states = self.memory_results[self._current_circuit_index or 0]
-        if basis_states is None:
-            return None
-        return QubitDevice.states_to_binary(basis_states, self.num_wires)
+        return self.memory_results[self._current_circuit_index or 0]
 
     @property
     def prob(self):

--- a/pennylane_ionq/device.py
+++ b/pennylane_ionq/device.py
@@ -23,6 +23,7 @@ import warnings
 from time import sleep
 
 import numpy as np
+import requests
 
 from pennylane import pauli_decompose, SparseHamiltonian
 from pennylane.devices import QubitDevice
@@ -130,6 +131,9 @@ class IonQDevice(QubitDevice):
         noise_seed (int): seed for the noise model random number generator, for reproducible noisy
             simulation results. Must be an integer between 1 and 2\ :sup:`31` - 1. Only used when ``noise_model`` is set.
             Defaults to None (random seed).
+        memory (bool): if True, use the per-shot measurement outcomes returned by the API as the
+            device samples, instead of generating samples locally from the returned probabilities.
+            Per-shot results are not available for ideal simulation. Defaults to False.
         dry_run (bool): If True, the job will be submitted by the API client but not processed remotely.
             Useful for obtaining cost estimates. Defaults to False.
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
@@ -182,6 +186,7 @@ class IonQDevice(QubitDevice):
         sharpen=None,
         noise_model=None,
         noise_seed=None,
+        memory=False,
         dry_run=False,
         metadata=None,
         timeout=None,
@@ -205,6 +210,14 @@ class IonQDevice(QubitDevice):
                 raise ValueError(
                     f"noise_seed must be an integer between 1 and 2^31 - 1, got {noise_seed}."
                 )
+        if not isinstance(memory, bool):
+            raise ValueError(f"memory must be a boolean, got {memory}.")
+        if memory and target == "simulator" and noise_model in (None, "ideal"):
+            warnings.warn(
+                "Per-shot results are not available for ideal simulation; samples "
+                "will be generated from the returned probabilities.",
+                UserWarning,
+            )
 
         super().__init__(wires=wires, shots=shots)
         self._current_circuit_index = None
@@ -217,10 +230,12 @@ class IonQDevice(QubitDevice):
         self.sharpen = sharpen
         self.noise_model = noise_model
         self.noise_seed = noise_seed
+        self.memory = memory
         self.dry_run = dry_run
         self.metadata = metadata
         self._operation_map = _GATESET_OPS[gateset]
         self.histograms = []
+        self.memory_results = None
         self._samples = None
 
         # API client configuration.
@@ -242,6 +257,7 @@ class IonQDevice(QubitDevice):
         self._current_circuit_index = None
         self._samples = None
         self.histograms = []
+        self.memory_results = None
         self.input = {
             "qubits": self.num_wires,
             "gateset": self.gateset,
@@ -631,11 +647,112 @@ class IonQDevice(QubitDevice):
         # state (as a base-10 integer string) to the probability
         # as a floating point value between 0 and 1.
         # e.g., {"0": 0.413, "9": 0.111, "17": 0.476}
+        # Multi-circuit job histograms are keyed by child job ID.
         some_inner_value = next(iter(job.data.value.values()))
         if isinstance(some_inner_value, dict):
+            child_ids = list(job.data.value.keys())
             self.histograms = list(job.data.value.values())
         else:
+            child_ids = None
             self.histograms = [job.data.value]
+
+        if self.memory and not (self.target == "simulator" and self.noise_model in (None, "ideal")):
+            self.memory_results = self._fetch_memory_results(job, child_ids)
+
+    def _fetch_memory_results(self, job, child_ids=None):
+        """Fetch per-shot measurement outcomes for each circuit of a completed job.
+
+        Args:
+            job (Job): the completed job resource.
+            child_ids (list[str] | None): child job IDs of a multi-circuit job,
+                ordered as in ``self.histograms``.
+
+        Returns:
+            list[array[int] or None]: one array of basis-state integers per circuit,
+            with ``None`` entries where per-shot results could not be retrieved.
+        """
+        manager = job.manager
+        if not child_ids:
+            results = (manager.http_response_data or {}).get("results") or {}
+            return [self._fetch_shots((results.get("shots") or {}).get("url"), manager)]
+
+        # The parent job only carries aggregated probabilities; each child job
+        # advertises its own per-shot results URL.
+        memory_results = []
+        for child_id in child_ids:
+            try:
+                response = manager.client.get(manager.join_path(str(child_id)))
+                response.raise_for_status()
+                results = response.json().get("results") or {}
+            except requests.exceptions.RequestException as e:
+                warnings.warn(
+                    f"Failed to retrieve per-shot results for job {child_id}: {e}. "
+                    "Samples for this circuit will be generated from the returned "
+                    "probabilities.",
+                    UserWarning,
+                )
+                memory_results.append(None)
+                continue
+            memory_results.append(
+                self._fetch_shots((results.get("shots") or {}).get("url"), manager)
+            )
+        return memory_results
+
+    def _fetch_shots(self, url, manager):
+        """Fetch a job's per-shot results and convert them to basis-state integers.
+
+        Args:
+            url (str | None): the job's ``results.shots.url``, if any.
+            manager (ResourceManager): the manager used for API requests.
+
+        Returns:
+            array[int] or None: one big-endian basis-state integer per shot, or
+            ``None`` if the per-shot results could not be retrieved.
+        """
+        if not url:
+            warnings.warn(
+                "The job did not report per-shot results; samples will be "
+                "generated from the returned probabilities.",
+                UserWarning,
+            )
+            return None
+        try:
+            response = manager.client.get(manager.join_path(url))
+            response.raise_for_status()
+            raw_shots = response.json()
+        except requests.exceptions.RequestException as e:
+            warnings.warn(
+                f"Failed to retrieve per-shot results: {e}. Samples will be "
+                "generated from the returned probabilities.",
+                UserWarning,
+            )
+            return None
+
+        # The API returns one decimal-encoded basis state per shot, in
+        # little-endian ordering like the histogram keys; rearrange to the
+        # big-endian ordering expected by PennyLane.
+        return np.fromiter(
+            (int(bin(int(s))[2:].rjust(self.num_wires, "0")[::-1], 2) for s in raw_shots),
+            dtype=np.int64,
+        )
+
+    def _memory_samples(self):
+        """Return the per-shot samples retrieved from the API for the current circuit.
+
+        Returns:
+            array[int] or None: binary samples of shape ``(shots, num_wires)``, or
+            ``None`` if per-shot results are not available.
+        """
+        if self.memory_results is None:
+            return None
+
+        if self._current_circuit_index is None and len(self.memory_results) > 1:
+            raise CircuitIndexNotSetException()
+
+        basis_states = self.memory_results[self._current_circuit_index or 0]
+        if basis_states is None:
+            return None
+        return QubitDevice.states_to_binary(basis_states, self.num_wires)
 
     @property
     def prob(self):
@@ -707,6 +824,9 @@ class SimulatorDevice(IonQDevice):
         noise_seed (int): seed for the noise model random number generator, for reproducible noisy
             simulation results. Must be an integer between 1 and 2\ :sup:`31` - 1. Only used when ``noise_model`` is set.
             Defaults to None (random seed).
+        memory (bool): if True, use the per-shot measurement outcomes returned by the API as the
+            device samples, instead of generating samples locally from the returned probabilities.
+            Per-shot results are not available for ideal simulation. Defaults to False.
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
         timeout (float): Request timeout in seconds. Defaults to None, which uses the
             ``APIClient`` default.
@@ -730,6 +850,7 @@ class SimulatorDevice(IonQDevice):
         api_key=None,
         noise_model=None,
         noise_seed=None,
+        memory=False,
         dry_run=False,
         metadata=None,
         timeout=None,
@@ -746,6 +867,7 @@ class SimulatorDevice(IonQDevice):
             compilation=compilation,
             noise_model=noise_model,
             noise_seed=noise_seed,
+            memory=memory,
             dry_run=dry_run,
             metadata=metadata,
             timeout=timeout,
@@ -754,7 +876,12 @@ class SimulatorDevice(IonQDevice):
         )
 
     def generate_samples(self):
-        """Generates samples by random sampling with the probabilities returned by the simulator."""
+        """Generates samples from the per-shot results if available, otherwise by
+        random sampling with the probabilities returned by the simulator."""
+        memory_samples = self._memory_samples()
+        if memory_samples is not None:
+            return memory_samples
+
         number_of_states = 2**self.num_wires
         samples = self.sample_basis_states(number_of_states, self.prob)
         return QubitDevice.states_to_binary(samples, self.num_wires)
@@ -790,6 +917,9 @@ class QPUDevice(IonQDevice):
             Defaults to None (no value passed at job retrieval). Will generally return more accurate results if
             your expected output distribution has peaks. See `IonQ Debiasing and Sharpening
             <https://ionq.com/resources/debiasing-and-sharpening>`_ for details.
+        memory (bool): if True, use the per-shot measurement outcomes returned by the API as the
+            device samples, instead of generating samples locally from the returned probabilities.
+            Defaults to False.
         dry_run (bool): whether to run the job in dry run mode. Defaults to False.
         metadata (dict | None): optional metadata to attach to the job. Defaults to None.
         timeout (float): Request timeout in seconds. Defaults to None, which uses the
@@ -816,6 +946,7 @@ class QPUDevice(IonQDevice):
         error_mitigation=None,
         sharpen=None,
         api_key=None,
+        memory=False,
         dry_run=False,
         metadata=None,
         timeout=None,
@@ -836,6 +967,7 @@ class QPUDevice(IonQDevice):
             compilation=compilation,
             error_mitigation=error_mitigation,
             sharpen=sharpen,
+            memory=memory,
             dry_run=dry_run,
             metadata=metadata,
             timeout=timeout,
@@ -846,10 +978,16 @@ class QPUDevice(IonQDevice):
     def generate_samples(self):
         """Generates samples from the qpu.
 
-        Note that the order of the samples returned here is not indicative of the order in which
-        the experiments were done, but is instead controlled by a random shuffle (and hence
-        set by numpy random seed).
+        If per-shot results were retrieved from the API, they are returned in the
+        order the shots were measured. Otherwise, samples are generated from the
+        returned probabilities, and their order is not indicative of the order in
+        which the experiments were done, but is instead controlled by a random
+        shuffle (and hence set by numpy random seed).
         """
+        memory_samples = self._memory_samples()
+        if memory_samples is not None:
+            return memory_samples
+
         number_of_states = 2**self.num_wires
         counts = np.rint(
             self.prob * self.shots,

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -107,10 +107,11 @@ class MockGETResponse(MockResponse):
 
 
 class TestAPIClient:
-    def test_init_default_client(self):
+    def test_init_default_client(self, monkeypatch):
         """
         Test that initializing a default client generates an APIClient with the expected params.
         """
+        monkeypatch.delenv("IONQ_API_HOSTNAME", raising=False)
         client = api_client.APIClient(api_key="test")
         assert client.USER_AGENT == "pennylane-ionq-api-client/0.4"
         assert client.HOSTNAME == "api.ionq.co/v0.4"
@@ -118,6 +119,17 @@ class TestAPIClient:
         assert client.BASE_URL.endswith(client.HOSTNAME)
         assert client.HEADERS["User-Agent"] == client.USER_AGENT
         assert client.TIMEOUT_SECONDS == 600
+
+    def test_hostname_env_override(self, monkeypatch):
+        """
+        Test that the IONQ_API_HOSTNAME environment variable overrides the default hostname.
+        """
+        other_api_url = "some_other_url.co"
+        monkeypatch.setenv("IONQ_API_HOSTNAME", other_api_url)
+        client = api_client.APIClient(api_key="test")
+        assert client.HOSTNAME == other_api_url
+        assert client.BASE_URL == "https://" + other_api_url
+        assert client.DEFAULT_HOSTNAME == "api.ionq.co/v0.4"
 
     def test_set_authorization_header(self):
         """

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -25,6 +25,7 @@ from pennylane_ionq.api_client import (
     Resource,
     Field,
     ResourceManager,
+    ResultsTypes,
     ObjectAlreadyCreatedException,
     MethodNotSupportedException,
 )
@@ -194,7 +195,9 @@ class TestResourceManager:
 
         # TODO test that this is called with correct path
         mock_client.get.assert_called_once()
-        manager.handle_response.assert_called_once_with(mock_response, params)
+        manager.handle_response.assert_called_once_with(
+            mock_response, params, results_type=ResultsTypes.PROBS
+        )
 
     def test_create_unsupported(self):
         """
@@ -269,7 +272,9 @@ class TestResourceManager:
 
         mock_response.status_code = 200
         manager.handle_response(mock_response)
-        mock_handle_success_response.assert_called_once_with(mock_response, params=None)
+        mock_handle_success_response.assert_called_once_with(
+            mock_response, params=None, results_type=ResultsTypes.PROBS
+        )
 
     def test_handle_response_non_json_error(self):
         """

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1219,8 +1219,8 @@ class TestMemoryResults:
     def _mock_api(monkeypatch, job_json, payloads, requested=None):
         """Patch requests to serve fake IonQ API responses.
 
-        ``payloads`` maps URLs to a JSON payload or a (payload, status_code)
-        tuple; ``requested`` collects the URLs of all GET requests.
+        ``payloads`` maps URLs to a JSON payload; ``requested`` collects the
+        URLs of all GET requests.
         """
 
         def fake_post(url, data=None, timeout=None, headers=None):
@@ -1229,10 +1229,7 @@ class TestMemoryResults:
         def fake_get(url, params=None, timeout=None, headers=None):
             if requested is not None:
                 requested.append(url)
-            payload = payloads[url]
-            if isinstance(payload, tuple):
-                return MockJSONResponse(*payload)
-            return MockJSONResponse(payload)
+            return MockJSONResponse(payloads[url])
 
         monkeypatch.setattr(requests, "post", fake_post)
         monkeypatch.setattr(requests, "get", fake_get)
@@ -1307,81 +1304,6 @@ class TestMemoryResults:
         assert np.array_equal(results[0], [[1, 0]] * 4)
         assert np.array_equal(results[1], [[0, 1]] * 4)
 
-    def test_memory_multi_circuit_partial_failure(self, monkeypatch):
-        """A failed child job fetch warns and falls back to sampling from the
-        probabilities for that circuit only."""
-        job_json = {
-            "id": "parent",
-            "status": "completed",
-            "results": {"probabilities": {"url": "/v0.4/jobs/parent/results/probabilities"}},
-        }
-        payloads = {
-            f"{API_URL}/jobs/parent": job_json,
-            f"{API_URL}/jobs/parent/results/probabilities": {
-                "child-a": {"1": 1.0},
-                "child-b": {"2": 1.0},
-            },
-            f"{API_URL}/jobs/child-a": {
-                "id": "child-a",
-                "status": "completed",
-                "results": {"shots": {"url": "/v0.4/jobs/child-a/results/shots"}},
-            },
-            f"{API_URL}/jobs/child-a/results/shots": ["1", "1", "1", "1"],
-            f"{API_URL}/jobs/child-b": ({}, 500),
-        }
-        self._mock_api(monkeypatch, job_json, payloads)
-
-        dev = SimulatorDevice(
-            wires=2,
-            shots=4,
-            api_key=FAKE_API_KEY,
-            noise_model="aria-1",
-            memory=True,
-            max_retries=0,
-        )
-        with pytest.warns(UserWarning, match="Failed to retrieve per-shot results for job"):
-            results = dev.batch_execute([self._sample_tape(4), self._sample_tape(4)])
-
-        assert np.array_equal(dev.memory_results[0], [2, 2, 2, 2])
-        assert dev.memory_results[1] is None
-        assert np.array_equal(results[0], [[1, 0]] * 4)
-        assert np.array_equal(results[1], [[0, 1]] * 4)
-
-    def test_memory_no_shots_url(self, monkeypatch):
-        """A job response without per-shot results warns and falls back to
-        sampling from the probabilities."""
-        job_json, payloads = self._single_circuit_payloads()
-        self._mock_api(monkeypatch, job_json, payloads)
-
-        dev = SimulatorDevice(
-            wires=2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1", memory=True
-        )
-        with pytest.warns(UserWarning, match="did not report per-shot results"):
-            results = dev.batch_execute([self._sample_tape(4)])
-
-        assert dev.memory_results == [None]
-        assert np.asarray(results[0]).shape == (4, 2)
-
-    def test_memory_fetch_error(self, monkeypatch):
-        """A failed per-shot results fetch warns and falls back to sampling
-        from the probabilities."""
-        job_json, payloads = self._single_circuit_payloads(({}, 500))
-        self._mock_api(monkeypatch, job_json, payloads)
-
-        dev = SimulatorDevice(
-            wires=2,
-            shots=4,
-            api_key=FAKE_API_KEY,
-            noise_model="aria-1",
-            memory=True,
-            max_retries=0,
-        )
-        with pytest.warns(UserWarning, match="Failed to retrieve per-shot results"):
-            results = dev.batch_execute([self._sample_tape(4)])
-
-        assert dev.memory_results == [None]
-        assert np.asarray(results[0]).shape == (4, 2)
-
     def test_memory_false_skips_fetch(self, monkeypatch):
         """No per-shot results are fetched when memory is False."""
         job_json, payloads = self._single_circuit_payloads(["1", "0", "3", "1"])
@@ -1422,7 +1344,7 @@ class TestMemoryResults:
         """generate_samples returns the fetched per-shot results in order."""
         dev = device_class(2, shots=4, api_key=FAKE_API_KEY, memory=True, **kwargs)
         dev.histograms = [{"0": 0.25, "2": 0.75}]
-        dev.memory_results = [np.array([2, 0, 2, 2])]
+        dev.memory_results = [np.array([[1, 0], [0, 0], [1, 0], [1, 0]])]
 
         samples = dev.generate_samples()
 
@@ -1431,7 +1353,7 @@ class TestMemoryResults:
     def test_memory_samples_require_circuit_index(self):
         """Sampling multi-circuit per-shot results without a circuit index raises."""
         dev = QPUDevice(2, shots=4, api_key=FAKE_API_KEY, memory=True)
-        dev.memory_results = [np.array([0]), np.array([1])]
+        dev.memory_results = [np.array([[0, 0]]), np.array([[0, 1]])]
 
         with pytest.raises(CircuitIndexNotSetException):
             dev.generate_samples()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1191,3 +1191,291 @@ class TestJobAttribute:
         assert "control" not in gate
         assert "target" not in gate
         assert gate["rotation"] == rotation
+
+
+API_URL = "https://api.ionq.co/v0.4"
+
+
+class MockJSONResponse:
+    """Mock requests response returning a JSON payload."""
+
+    def __init__(self, json_data, status_code=200):
+        self.status_code = status_code
+        self._json = json_data
+        self.text = json.dumps(json_data)
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"{self.status_code} error")
+
+
+class TestMemoryResults:
+    """Tests for retrieving per-shot results with the memory device kwarg."""
+
+    @staticmethod
+    def _mock_api(monkeypatch, job_json, payloads, requested=None):
+        """Patch requests to serve fake IonQ API responses.
+
+        ``payloads`` maps URLs to a JSON payload or a (payload, status_code)
+        tuple; ``requested`` collects the URLs of all GET requests.
+        """
+
+        def fake_post(url, data=None, timeout=None, headers=None):
+            return MockJSONResponse(job_json, 201)
+
+        def fake_get(url, params=None, timeout=None, headers=None):
+            if requested is not None:
+                requested.append(url)
+            payload = payloads[url]
+            if isinstance(payload, tuple):
+                return MockJSONResponse(*payload)
+            return MockJSONResponse(payload)
+
+        monkeypatch.setattr(requests, "post", fake_post)
+        monkeypatch.setattr(requests, "get", fake_get)
+
+    @staticmethod
+    def _single_circuit_payloads(shots_payload=None):
+        """Build a completed single-circuit job response and its result payloads."""
+        results = {"probabilities": {"url": "/v0.4/jobs/job-1/results/probabilities"}}
+        payloads = {
+            f"{API_URL}/jobs/job-1/results/probabilities": {"0": 0.5, "1": 0.5},
+        }
+        if shots_payload is not None:
+            results["shots"] = {"url": "/v0.4/jobs/job-1/results/shots"}
+            payloads[f"{API_URL}/jobs/job-1/results/shots"] = shots_payload
+        job_json = {"id": "job-1", "status": "completed", "results": results}
+        payloads[f"{API_URL}/jobs/job-1"] = job_json
+        return job_json, payloads
+
+    @staticmethod
+    def _sample_tape(shots):
+        with qml.tape.QuantumTape(shots=shots) as tape:
+            qml.PauliX(0)
+            qml.sample(wires=[0, 1])
+        return tape
+
+    def test_memory_single_circuit(self, monkeypatch):
+        """Per-shot results of a single-circuit job are returned as samples,
+        in order and with little-endian API states mapped to PennyLane wires."""
+        job_json, payloads = self._single_circuit_payloads(["1", "0", "3", "1"])
+        self._mock_api(monkeypatch, job_json, payloads)
+
+        dev = SimulatorDevice(
+            wires=2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1", memory=True
+        )
+        results = dev.batch_execute([self._sample_tape(4)])
+
+        assert np.array_equal(results[0], [[1, 0], [0, 0], [1, 1], [1, 0]])
+
+    def test_memory_multi_circuit(self, monkeypatch):
+        """Per-shot results of a multi-circuit job are fetched from each child job."""
+        job_json = {
+            "id": "parent",
+            "status": "completed",
+            "results": {"probabilities": {"url": "/v0.4/jobs/parent/results/probabilities"}},
+        }
+        payloads = {
+            f"{API_URL}/jobs/parent": job_json,
+            f"{API_URL}/jobs/parent/results/probabilities": {
+                "child-a": {"1": 1.0},
+                "child-b": {"2": 1.0},
+            },
+            f"{API_URL}/jobs/child-a": {
+                "id": "child-a",
+                "status": "completed",
+                "results": {"shots": {"url": "/v0.4/jobs/child-a/results/shots"}},
+            },
+            f"{API_URL}/jobs/child-b": {
+                "id": "child-b",
+                "status": "completed",
+                "results": {"shots": {"url": "/v0.4/jobs/child-b/results/shots"}},
+            },
+            f"{API_URL}/jobs/child-a/results/shots": ["1", "1", "1", "1"],
+            f"{API_URL}/jobs/child-b/results/shots": ["2", "2", "2", "2"],
+        }
+        self._mock_api(monkeypatch, job_json, payloads)
+
+        dev = SimulatorDevice(
+            wires=2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1", memory=True
+        )
+        results = dev.batch_execute([self._sample_tape(4), self._sample_tape(4)])
+
+        assert np.array_equal(results[0], [[1, 0]] * 4)
+        assert np.array_equal(results[1], [[0, 1]] * 4)
+
+    def test_memory_multi_circuit_partial_failure(self, monkeypatch):
+        """A failed child job fetch warns and falls back to sampling from the
+        probabilities for that circuit only."""
+        job_json = {
+            "id": "parent",
+            "status": "completed",
+            "results": {"probabilities": {"url": "/v0.4/jobs/parent/results/probabilities"}},
+        }
+        payloads = {
+            f"{API_URL}/jobs/parent": job_json,
+            f"{API_URL}/jobs/parent/results/probabilities": {
+                "child-a": {"1": 1.0},
+                "child-b": {"2": 1.0},
+            },
+            f"{API_URL}/jobs/child-a": {
+                "id": "child-a",
+                "status": "completed",
+                "results": {"shots": {"url": "/v0.4/jobs/child-a/results/shots"}},
+            },
+            f"{API_URL}/jobs/child-a/results/shots": ["1", "1", "1", "1"],
+            f"{API_URL}/jobs/child-b": ({}, 500),
+        }
+        self._mock_api(monkeypatch, job_json, payloads)
+
+        dev = SimulatorDevice(
+            wires=2,
+            shots=4,
+            api_key=FAKE_API_KEY,
+            noise_model="aria-1",
+            memory=True,
+            max_retries=0,
+        )
+        with pytest.warns(UserWarning, match="Failed to retrieve per-shot results for job"):
+            results = dev.batch_execute([self._sample_tape(4), self._sample_tape(4)])
+
+        assert np.array_equal(dev.memory_results[0], [2, 2, 2, 2])
+        assert dev.memory_results[1] is None
+        assert np.array_equal(results[0], [[1, 0]] * 4)
+        assert np.array_equal(results[1], [[0, 1]] * 4)
+
+    def test_memory_no_shots_url(self, monkeypatch):
+        """A job response without per-shot results warns and falls back to
+        sampling from the probabilities."""
+        job_json, payloads = self._single_circuit_payloads()
+        self._mock_api(monkeypatch, job_json, payloads)
+
+        dev = SimulatorDevice(
+            wires=2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1", memory=True
+        )
+        with pytest.warns(UserWarning, match="did not report per-shot results"):
+            results = dev.batch_execute([self._sample_tape(4)])
+
+        assert dev.memory_results == [None]
+        assert np.asarray(results[0]).shape == (4, 2)
+
+    def test_memory_fetch_error(self, monkeypatch):
+        """A failed per-shot results fetch warns and falls back to sampling
+        from the probabilities."""
+        job_json, payloads = self._single_circuit_payloads(({}, 500))
+        self._mock_api(monkeypatch, job_json, payloads)
+
+        dev = SimulatorDevice(
+            wires=2,
+            shots=4,
+            api_key=FAKE_API_KEY,
+            noise_model="aria-1",
+            memory=True,
+            max_retries=0,
+        )
+        with pytest.warns(UserWarning, match="Failed to retrieve per-shot results"):
+            results = dev.batch_execute([self._sample_tape(4)])
+
+        assert dev.memory_results == [None]
+        assert np.asarray(results[0]).shape == (4, 2)
+
+    def test_memory_false_skips_fetch(self, monkeypatch):
+        """No per-shot results are fetched when memory is False."""
+        job_json, payloads = self._single_circuit_payloads(["1", "0", "3", "1"])
+        requested = []
+        self._mock_api(monkeypatch, job_json, payloads, requested=requested)
+
+        dev = SimulatorDevice(wires=2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1")
+        dev.batch_execute([self._sample_tape(4)])
+
+        assert dev.memory_results is None
+        assert f"{API_URL}/jobs/job-1/results/shots" not in requested
+
+    @pytest.mark.parametrize("noise_model", [None, "ideal"])
+    def test_memory_ideal_simulator(self, noise_model, monkeypatch):
+        """Requesting memory on the ideal simulator warns and skips the fetch."""
+        job_json, payloads = self._single_circuit_payloads()
+        requested = []
+        self._mock_api(monkeypatch, job_json, payloads, requested=requested)
+
+        with pytest.warns(UserWarning, match="not available for ideal simulation"):
+            dev = SimulatorDevice(
+                wires=2, shots=4, api_key=FAKE_API_KEY, noise_model=noise_model, memory=True
+            )
+        dev.batch_execute([self._sample_tape(4)])
+
+        assert dev.memory_results is None
+
+    def test_memory_invalid_type(self):
+        """A non-boolean memory argument raises a ValueError."""
+        with pytest.raises(ValueError, match="memory must be a boolean"):
+            SimulatorDevice(wires=2, shots=4, api_key=FAKE_API_KEY, memory="yes")
+
+    @pytest.mark.parametrize(
+        "device_class, kwargs",
+        [(SimulatorDevice, {"noise_model": "aria-1"}), (QPUDevice, {})],
+    )
+    def test_generate_samples_from_memory(self, device_class, kwargs):
+        """generate_samples returns the fetched per-shot results in order."""
+        dev = device_class(2, shots=4, api_key=FAKE_API_KEY, memory=True, **kwargs)
+        dev.histograms = [{"0": 0.25, "2": 0.75}]
+        dev.memory_results = [np.array([2, 0, 2, 2])]
+
+        samples = dev.generate_samples()
+
+        assert np.array_equal(samples, [[1, 0], [0, 0], [1, 0], [1, 0]])
+
+    def test_memory_samples_require_circuit_index(self):
+        """Sampling multi-circuit per-shot results without a circuit index raises."""
+        dev = QPUDevice(2, shots=4, api_key=FAKE_API_KEY, memory=True)
+        dev.memory_results = [np.array([0]), np.array([1])]
+
+        with pytest.raises(CircuitIndexNotSetException):
+            dev.generate_samples()
+
+    def test_memory_none_entry_falls_back(self):
+        """A missing per-shot results entry falls back to probability sampling."""
+        dev = SimulatorDevice(2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1", memory=True)
+        dev.histograms = [{"0": 1.0}]
+        dev.memory_results = [None]
+
+        samples = dev.generate_samples()
+
+        assert np.array_equal(samples, np.zeros((4, 2)))
+
+    def test_memory_single_circuit_api(self, requires_api):
+        """Per-shot results are used as samples on a noisy-simulator job."""
+        dev = qml.device("ionq.simulator", wires=3, noise_model="aria-1", memory=True)
+
+        with qml.tape.QuantumTape(shots=100) as tape:
+            qml.PauliX(1)
+            qml.sample(wires=[0, 1, 2])
+
+        results = dev.batch_execute([tape])
+
+        assert len(dev.memory_results) == 1
+        assert dev.memory_results[0] is not None
+        unique, counts = np.unique(results[0], axis=0, return_counts=True)
+        assert np.array_equal(unique[np.argmax(counts)], [0, 1, 0])
+
+    def test_memory_two_circuits_api(self, requires_api):
+        """Per-shot results are matched to the right circuit and wire ordering
+        on a multi-circuit job."""
+        dev = qml.device("ionq.simulator", wires=3, noise_model="aria-1", memory=True)
+
+        with qml.tape.QuantumTape(shots=100) as tape1:
+            qml.PauliX(0)
+            qml.sample(wires=[0, 1, 2])
+
+        with qml.tape.QuantumTape(shots=100) as tape2:
+            qml.PauliX(2)
+            qml.sample(wires=[0, 1, 2])
+
+        results = dev.batch_execute([tape1, tape2])
+
+        for result, expected in zip(results, ([1, 0, 0], [0, 0, 1])):
+            unique, counts = np.unique(result, axis=0, return_counts=True)
+            assert np.array_equal(unique[np.argmax(counts)], expected)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1214,7 +1214,7 @@ class MockJSONResponse:
 
 
 class TestMemoryResults:
-    """Tests for retrieving per-shot results with the memory device kwarg."""
+    """Tests for retrieving shotwise results with the memory device kwarg."""
 
     @staticmethod
     def _mock_api(monkeypatch, job_json, payloads, requested=None):
@@ -1260,7 +1260,7 @@ class TestMemoryResults:
         return tape
 
     def test_memory_single_circuit(self, monkeypatch):
-        """Per-shot results of a single-circuit job are returned as samples,
+        """Shotwise results of a single-circuit job are returned as samples,
         in order and with little-endian API states mapped to PennyLane wires."""
         job_json, payloads = self._single_circuit_payloads(["1", "0", "3", "1"])
         self._mock_api(monkeypatch, job_json, payloads)
@@ -1273,7 +1273,7 @@ class TestMemoryResults:
         assert np.array_equal(results[0], [[1, 0], [0, 0], [1, 1], [1, 0]])
 
     def test_memory_multi_circuit(self, monkeypatch):
-        """Per-shot results of a multi-circuit job are fetched from each child job."""
+        """Shotwise results of a multi-circuit job are fetched from each child job."""
         job_json = {
             "id": "parent",
             "status": "completed",
@@ -1309,7 +1309,7 @@ class TestMemoryResults:
         assert np.array_equal(results[1], [[0, 1]] * 4)
 
     def test_memory_false_skips_fetch(self, monkeypatch):
-        """No per-shot results are fetched when memory is False."""
+        """No shotwise results are fetched when memory is False."""
         job_json, payloads = self._single_circuit_payloads(["1", "0", "3", "1"])
         requested = []
         self._mock_api(monkeypatch, job_json, payloads, requested=requested)
@@ -1335,17 +1335,12 @@ class TestMemoryResults:
 
         assert dev.memory_results is None
 
-    def test_memory_invalid_type(self):
-        """A non-boolean memory argument raises a ValueError."""
-        with pytest.raises(ValueError, match="memory must be a boolean"):
-            SimulatorDevice(wires=2, shots=4, api_key=FAKE_API_KEY, memory="yes")
-
     @pytest.mark.parametrize(
         "device_class, kwargs",
         [(SimulatorDevice, {"noise_model": "aria-1"}), (QPUDevice, {})],
     )
     def test_generate_samples_from_memory(self, device_class, kwargs):
-        """generate_samples returns the fetched per-shot results in order."""
+        """generate_samples returns the fetched shotwise results in order."""
         dev = device_class(2, shots=4, api_key=FAKE_API_KEY, memory=True, **kwargs)
         dev.histograms = [{"0": 0.25, "2": 0.75}]
         dev.memory_results = [np.array([[1, 0], [0, 0], [1, 0], [1, 0]])]
@@ -1355,7 +1350,7 @@ class TestMemoryResults:
         assert np.array_equal(samples, [[1, 0], [0, 0], [1, 0], [1, 0]])
 
     def test_memory_samples_require_circuit_index(self):
-        """Sampling multi-circuit per-shot results without a circuit index raises."""
+        """Sampling multi-circuit shotwise results without a circuit index raises."""
         dev = QPUDevice(2, shots=4, api_key=FAKE_API_KEY, memory=True)
         dev.memory_results = [np.array([[0, 0]]), np.array([[0, 1]])]
 
@@ -1363,7 +1358,7 @@ class TestMemoryResults:
             dev.generate_samples()
 
     def test_memory_none_entry_falls_back(self):
-        """A missing per-shot results entry falls back to probability sampling."""
+        """A missing shotwise results entry falls back to probability sampling."""
         dev = SimulatorDevice(2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1", memory=True)
         dev.histograms = [{"0": 1.0}]
         dev.memory_results = None
@@ -1373,7 +1368,7 @@ class TestMemoryResults:
         assert np.array_equal(samples, np.zeros((4, 2)))
 
     def test_memory_single_circuit_api(self, requires_api):
-        """Per-shot results are used as samples on a noisy-simulator job."""
+        """Shotwise results are used as samples on a noisy-simulator job."""
         dev = qml.device("ionq.simulator", wires=3, noise_model="aria-1", memory=True)
 
         with qml.tape.QuantumTape(shots=100) as tape:
@@ -1388,7 +1383,7 @@ class TestMemoryResults:
         assert np.array_equal(unique[np.argmax(counts)], [0, 1, 0])
 
     def test_memory_two_circuits_api(self, requires_api):
-        """Per-shot results are matched to the right circuit and wire ordering
+        """Shotwise results are matched to the right circuit and wire ordering
         on a multi-circuit job."""
         dev = qml.device("ionq.simulator", wires=3, noise_model="aria-1", memory=True)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -146,7 +146,7 @@ class TestDeviceIntegration:
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
-        def fake_response(self, resource_id=None, params=None):
+        def fake_response(self, resource_id=None, params=None, results_type=None):
             """Return fake response data"""
             fake_json = {"0": 1}
             setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
@@ -174,7 +174,7 @@ class TestDeviceIntegration:
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
-        def fake_response(self, resource_id=None, params=None):
+        def fake_response(self, resource_id=None, params=None, results_type=None):
             """Return fake response data"""
             fake_json = {"0": 1}
             setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
@@ -216,7 +216,7 @@ class TestDeviceIntegration:
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
-        def fake_response(self, resource_id=None, params=None):
+        def fake_response(self, resource_id=None, params=None, results_type=None):
             """Return fake response data"""
             fake_json = {"0": 1}
             setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
@@ -254,7 +254,7 @@ class TestDeviceIntegration:
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
-        def fake_response(self, resource_id=None, params=None):
+        def fake_response(self, resource_id=None, params=None, results_type=None):
             """Return fake response data"""
             fake_json = {"0": 1}
             setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
@@ -288,7 +288,7 @@ class TestDeviceIntegration:
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
-        def fake_response(self, resource_id=None, params=None):
+        def fake_response(self, resource_id=None, params=None, results_type=None):
             """Return fake response data"""
             fake_json = {"0": 1}
             setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
@@ -318,7 +318,7 @@ class TestDeviceIntegration:
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
-        def fake_response(self, resource_id=None, params=None):
+        def fake_response(self, resource_id=None, params=None, results_type=None):
             """Return fake response data"""
             fake_json = {"0": 1}
             setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
@@ -357,7 +357,7 @@ class TestDeviceIntegration:
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
-        def fake_response(self, resource_id=None, params=None):
+        def fake_response(self, resource_id=None, params=None, results_type=None):
             """Return fake response data"""
             fake_json = {"0": 1}
             setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
@@ -408,7 +408,7 @@ class TestDeviceIntegration:
         monkeypatch.setattr(ResourceManager, "handle_response", lambda self, response: None)
         monkeypatch.setattr(Job, "is_complete", True)
 
-        def fake_response(self, resource_id=None, params=None):
+        def fake_response(self, resource_id=None, params=None, results_type=None):
             """Return fake response data"""
             fake_json = {"0": 1}
             setattr(self.resource, "data", type("data", tuple(), {"value": fake_json})())
@@ -1362,7 +1362,7 @@ class TestMemoryResults:
         """A missing per-shot results entry falls back to probability sampling."""
         dev = SimulatorDevice(2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1", memory=True)
         dev.histograms = [{"0": 1.0}]
-        dev.memory_results = [None]
+        dev.memory_results = None
 
         samples = dev.generate_samples()
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1216,59 +1216,40 @@ class MockJSONResponse:
 class TestMemoryResults:
     """Tests for retrieving shotwise results with the memory device kwarg."""
 
-    @staticmethod
-    def _mock_api(monkeypatch, job_json, payloads, requested=None):
-        """Patch requests to serve fake IonQ API responses.
-
-        ``payloads`` maps URLs to a JSON payload; ``requested`` collects the
-        URLs of all GET requests. The API hostname is pinned to ``TEST_HOSTNAME``
-        so that payload lookups work regardless of any ``IONQ_API_HOSTNAME``
-        set in the environment.
-        """
+    def test_memory_single_circuit(self, monkeypatch):
+        """Shotwise results of a single-circuit job are returned as samples,
+        in order and with little-endian API states mapped to PennyLane wires."""
         monkeypatch.setenv("IONQ_API_HOSTNAME", TEST_HOSTNAME)
+
+        shots_payload = ["1", "0", "3", "1"]
+
+        results = {
+            "probabilities": {"url": "/v0.4/jobs/job-1/results/probabilities"},
+            "shots": {"url": "/v0.4/jobs/job-1/results/shots"}
+                   }
+        job_json = {"id": "job-1", "status": "completed", "results": results}
+        payloads = {
+            f"{API_URL}/jobs/job-1": job_json,
+            f"{API_URL}/jobs/job-1/results/probabilities": {"0": 0.5, "1": 0.5},
+            f"{API_URL}/jobs/job-1/results/shots": shots_payload,
+        }
 
         def fake_post(url, data=None, timeout=None, headers=None):
             return MockJSONResponse(job_json, 201)
 
         def fake_get(url, params=None, timeout=None, headers=None):
-            if requested is not None:
-                requested.append(url)
             return MockJSONResponse(payloads[url])
 
         monkeypatch.setattr(requests, "post", fake_post)
         monkeypatch.setattr(requests, "get", fake_get)
 
-    @staticmethod
-    def _single_circuit_payloads(shots_payload=None):
-        """Build a completed single-circuit job response and its result payloads."""
-        results = {"probabilities": {"url": "/v0.4/jobs/job-1/results/probabilities"}}
-        payloads = {
-            f"{API_URL}/jobs/job-1/results/probabilities": {"0": 0.5, "1": 0.5},
-        }
-        if shots_payload is not None:
-            results["shots"] = {"url": "/v0.4/jobs/job-1/results/shots"}
-            payloads[f"{API_URL}/jobs/job-1/results/shots"] = shots_payload
-        job_json = {"id": "job-1", "status": "completed", "results": results}
-        payloads[f"{API_URL}/jobs/job-1"] = job_json
-        return job_json, payloads
-
-    @staticmethod
-    def _sample_tape(shots):
-        with qml.tape.QuantumTape(shots=shots) as tape:
-            qml.PauliX(0)
-            qml.sample(wires=[0, 1])
-        return tape
-
-    def test_memory_single_circuit(self, monkeypatch):
-        """Shotwise results of a single-circuit job are returned as samples,
-        in order and with little-endian API states mapped to PennyLane wires."""
-        job_json, payloads = self._single_circuit_payloads(["1", "0", "3", "1"])
-        self._mock_api(monkeypatch, job_json, payloads)
-
         dev = SimulatorDevice(
             wires=2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1", memory=True
         )
-        results = dev.batch_execute([self._sample_tape(4)])
+        with qml.tape.QuantumTape() as tape:
+            qml.PauliX(0)
+            qml.sample(wires=[0, 1])
+        results = dev.batch_execute([tape])
 
         assert np.array_equal(results[0], [[1, 0], [0, 0], [1, 1], [1, 0]])
 
@@ -1298,24 +1279,65 @@ class TestMemoryResults:
             f"{API_URL}/jobs/child-a/results/shots": ["1", "1", "1", "1"],
             f"{API_URL}/jobs/child-b/results/shots": ["2", "2", "2", "2"],
         }
-        self._mock_api(monkeypatch, job_json, payloads)
+        monkeypatch.setenv("IONQ_API_HOSTNAME", TEST_HOSTNAME)
+
+        def fake_post(url, data=None, timeout=None, headers=None):
+            return MockJSONResponse(job_json, 201)
+
+        def fake_get(url, params=None, timeout=None, headers=None):
+            return MockJSONResponse(payloads[url])
+
+        monkeypatch.setattr(requests, "post", fake_post)
+        monkeypatch.setattr(requests, "get", fake_get)
 
         dev = SimulatorDevice(
             wires=2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1", memory=True
         )
-        results = dev.batch_execute([self._sample_tape(4), self._sample_tape(4)])
+        with qml.tape.QuantumTape() as tape:
+            qml.PauliX(0)
+            qml.sample(wires=[0, 1])
+
+        results = dev.batch_execute([tape, tape])
 
         assert np.array_equal(results[0], [[1, 0]] * 4)
         assert np.array_equal(results[1], [[0, 1]] * 4)
 
     def test_memory_false_skips_fetch(self, monkeypatch):
         """No shotwise results are fetched when memory is False."""
-        job_json, payloads = self._single_circuit_payloads(["1", "0", "3", "1"])
+        shots_payload = ["1", "0", "3", "1"]
+
+        results = {
+            "probabilities": {"url": "/v0.4/jobs/job-1/results/probabilities"},
+            "shots": {"url": "/v0.4/jobs/job-1/results/shots"}
+                   }
+        job_json = {"id": "job-1", "status": "completed", "results": results}
+        payloads = {
+            f"{API_URL}/jobs/job-1": job_json,
+            f"{API_URL}/jobs/job-1/results/probabilities": {"0": 0.5, "1": 0.5},
+            f"{API_URL}/jobs/job-1/results/shots": shots_payload,
+        }
         requested = []
-        self._mock_api(monkeypatch, job_json, payloads, requested=requested)
+
+        monkeypatch.setenv("IONQ_API_HOSTNAME", TEST_HOSTNAME)
+
+        def fake_post(url, data=None, timeout=None, headers=None):
+            return MockJSONResponse(job_json, 201)
+
+        def fake_get(url, params=None, timeout=None, headers=None):
+            if requested is not None:
+                requested.append(url)
+            return MockJSONResponse(payloads[url])
+
+        monkeypatch.setattr(requests, "post", fake_post)
+        monkeypatch.setattr(requests, "get", fake_get)
 
         dev = SimulatorDevice(wires=2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1")
-        dev.batch_execute([self._sample_tape(4)])
+
+        with qml.tape.QuantumTape() as tape:
+            qml.PauliX(0)
+            qml.sample(wires=[0, 1])
+
+        dev.batch_execute([tape])
 
         assert dev.memory_results is None
         assert f"{API_URL}/jobs/job-1/results/shots" not in requested
@@ -1323,15 +1345,42 @@ class TestMemoryResults:
     @pytest.mark.parametrize("noise_model", [None, "ideal"])
     def test_memory_ideal_simulator(self, noise_model, monkeypatch):
         """Requesting memory on the ideal simulator warns and skips the fetch."""
-        job_json, payloads = self._single_circuit_payloads()
+        shots_payload = None
+
+        results = {
+            "probabilities": {"url": "/v0.4/jobs/job-1/results/probabilities"},
+            "shots": {"url": "/v0.4/jobs/job-1/results/shots"}
+                   }
+        job_json = {"id": "job-1", "status": "completed", "results": results}
+        payloads = {
+            f"{API_URL}/jobs/job-1": job_json,
+            f"{API_URL}/jobs/job-1/results/probabilities": {"0": 0.5, "1": 0.5},
+            f"{API_URL}/jobs/job-1/results/shots": shots_payload,
+        }
         requested = []
-        self._mock_api(monkeypatch, job_json, payloads, requested=requested)
+        monkeypatch.setenv("IONQ_API_HOSTNAME", TEST_HOSTNAME)
+
+        def fake_post(url, data=None, timeout=None, headers=None):
+            return MockJSONResponse(job_json, 201)
+
+        def fake_get(url, params=None, timeout=None, headers=None):
+            if requested is not None:
+                requested.append(url)
+            return MockJSONResponse(payloads[url])
+
+        monkeypatch.setattr(requests, "post", fake_post)
+        monkeypatch.setattr(requests, "get", fake_get)
 
         with pytest.warns(UserWarning, match="not available for ideal simulation"):
             dev = SimulatorDevice(
                 wires=2, shots=4, api_key=FAKE_API_KEY, noise_model=noise_model, memory=True
             )
-        dev.batch_execute([self._sample_tape(4)])
+
+        with qml.tape.QuantumTape() as tape:
+            qml.PauliX(0)
+            qml.sample(wires=[0, 1])
+
+        dev.batch_execute([tape])
 
         assert dev.memory_results is None
 
@@ -1359,9 +1408,10 @@ class TestMemoryResults:
 
     def test_memory_none_entry_falls_back(self):
         """A missing shotwise results entry falls back to probability sampling."""
-        dev = SimulatorDevice(2, shots=4, api_key=FAKE_API_KEY, noise_model="aria-1", memory=True)
+        with pytest.warns(UserWarning, match=r"Shotwise results are not available"):
+            dev = SimulatorDevice(2, shots=4, api_key=FAKE_API_KEY, memory=True)
+
         dev.histograms = [{"0": 1.0}]
-        dev.memory_results = None
 
         samples = dev.generate_samples()
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1193,7 +1193,8 @@ class TestJobAttribute:
         assert gate["rotation"] == rotation
 
 
-API_URL = "https://api.ionq.co/v0.4"
+TEST_HOSTNAME = "api.example.com/v0.4"
+API_URL = f"https://{TEST_HOSTNAME}"
 
 
 class MockJSONResponse:
@@ -1220,8 +1221,11 @@ class TestMemoryResults:
         """Patch requests to serve fake IonQ API responses.
 
         ``payloads`` maps URLs to a JSON payload; ``requested`` collects the
-        URLs of all GET requests.
+        URLs of all GET requests. The API hostname is pinned to ``TEST_HOSTNAME``
+        so that payload lookups work regardless of any ``IONQ_API_HOSTNAME``
+        set in the environment.
         """
+        monkeypatch.setenv("IONQ_API_HOSTNAME", TEST_HOSTNAME)
 
         def fake_post(url, data=None, timeout=None, headers=None):
             return MockJSONResponse(job_json, 201)


### PR DESCRIPTION
**Context**

Some IonQ devices from the Cloud support providing shotwise outputs for circuit runs - turning on `memory` to can enable getting such data.

**Changes**

* Adds the `memory` kwarg to IonQ devices to support shotwise outputs;
* Under the hood, the device gets the shotwise endpoint only when requested;
* Do not attempt shotwise for ideal simulations.

**Note**

Supercedes #178.